### PR TITLE
Problem: No way to encode module as Lean data

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -7,6 +7,8 @@ import Wasm.Wast.Num
 import Megaparsec.Parsec
 
 open Wasm.Wast.Code
+open Wasm.Wast.Code.Func
+open Wasm.Wast.Code.Module
 open Wasm.Wast.Code.Operation
 open Wasm.Wast.Expr
 open Wasm.Wast.Name
@@ -74,6 +76,90 @@ def main : IO Unit := do
   IO.println "(i32.add (i32.const 42)) is represented as:"
   void $ parseTestP addP "(i32.add (i32.const 42))"
   IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(func)"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP funcP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "param $t i32"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP paramP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(param $t i32) (param $coocoo f32)"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP nilParamsP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(param i32) (param $coocoo f32)  ( param i64 ) ( something_else )"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP nilParamsP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "( result i32)"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP brResultP i
+  IO.println "* * *"
+
+  -- IO.println "* * *"
+  -- let i := "(func (param $x i32) (param $y i32) (result i32)
+  --   (i32.add (local.get $y) (local.get $x))
+  -- )"
+  -- IO.println s!"{i} is represented as:"
+  -- void $ parseTestP funcP i
+  -- IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(func (param $x i32) (param $y i32) (result i32)
+  )"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP funcP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(func (param $x i32) (param i32) (result i32))"
+  -- unnamed param should have id 1
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP funcP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))"
+  -- unnamed param should have id 1
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP funcP i
+  /-
+  (Func.mk
+    none
+    none
+    [ (Local.name (LocalName.mk x (Type'.i (32 : BitSize))))
+    , (Local.index (LocalIndex.mk 1 (Type'.i (32 : BitSize)))) ]
+    (some (Type'.i (32 : BitSize)))
+    []
+    [
+      (Operation.add
+        (Add'.i32
+          (Get.const (Sum.inl (ConstInt (32 : BitSize) 40)) : Get (Type'.i (32 : BitSize)))
+          (Get.const (Sum.inl (ConstInt (32 : BitSize)  2)) : Get (Type'.i (32 : BitSize)))
+        )
+    ]
+  )
+  -/
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(module
+    (func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))
+  )"
+  -- unnamed param should have id 1
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP moduleP i
 
   let mut x := 0
   x := 1

--- a/Wasm/Wast/Name.lean
+++ b/Wasm/Wast/Name.lean
@@ -1,12 +1,21 @@
 import YatimaStdLib
+import Megaparsec.Common
+import Megaparsec.Parsec
 
 open Cached
+open Megaparsec.Common
+open Megaparsec.Parsec
 
 namespace Wasm.Wast.Name
 
 /- Chars that are allowed in WASM ids. -/
 def isIdChar (x : Char) : Bool :=
   x.isAlphanum || "_.+-*/\\^~=<>!?@#$%&|:'`".data.elem x
+
+/- This is how desperate coding looks. We started with dependent parsing, and ended up here.
+Well, at least we aren't using unsafe funcitons for parsing. 🤷 -/
+def nameP : Parsec Char String Unit String :=
+  string "$" *> ((many' $ satisfy isIdChar) >>= (pure ∘ String.mk))
 
 /- Captures a valid WAST identifier. -/
 structure Name (x : String) where

--- a/Wasm/Wast/Parser/Common.lean
+++ b/Wasm/Wast/Parser/Common.lean
@@ -2,6 +2,7 @@ import Megaparsec.MonadParsec
 import Megaparsec.Common
 import Megaparsec.Errors
 
+open MonadParsec
 open Megaparsec.Parsec
 open Megaparsec.Common
 open Megaparsec.Errors
@@ -21,3 +22,8 @@ def notSpecialP : Parsec Char String Unit Char :=
 
 def hints0 (β : Type u) [Ord β] : Std.RBSet (ErrorItem β) Ord.compare :=
   Std.mkRBSet (ErrorItem β) Ord.compare
+
+def optional (x : Option α) (d : α) : α :=
+    match x with
+    | .none => d
+    | .some y => y


### PR DESCRIPTION
Solution:

 - An important step in the direction of having end-to-end Wasm parser and runtime is being able to parse whole modules.
 - To do that, we have to implement module parser.
 - To implement module parser, we need to have a function parser.
 - We did it within the limitations we have (we currently can't parse all the operations even from the set we plan to support in the initial e2e test).
 - To side-step the limitations a bit, we wrapped `add` into `operation`.
 - We made `opsP` that wraps `addP` for the same reason.