### PR TITLE
Problem: there is no way to run webassembly in Lean

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -1,4 +1,5 @@
 import Wasm
+import Wasm.Engine
 import Wasm.Wast.Code
 import Wasm.Wast.Expr
 import Wasm.Wast.Name
@@ -9,6 +10,7 @@ import Wasm.Leb128
 import Megaparsec.Parsec
 
 open Wasm.Bytes
+open Wasm.Engine
 open Wasm.Wast.Code
 open Wasm.Wast.Code.Func
 open Wasm.Wast.Code.Module
@@ -22,6 +24,7 @@ open Num.Digit
 open Num.Nat
 open Num.Int
 open Num.Float
+open Wasm.Wast.Num.Uni
 
 open Megaparsec.Parsec
 
@@ -178,12 +181,34 @@ def main : IO Unit := do
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/special.wasm"
     let f := System.mkFilePath ["/tmp", "special.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/special.wasm"
 
 
+  let i := s!"(module
+        (func (export \"two_ints\")
+            (result i32) (result i32)
+            (i32.add
+                (i32.const 1499550000)
+                (i32.add (i32.const 9000) (i32.const 17))
+            )
+            (i32.add (i32.const -1) (i32.const 1))
+        )
+    )"
+
+  -- unnamed param should have id 1
+  IO.println s!"{i} is represented as:"
+  let o_parsed_module ← parseTestP moduleP i
+  match o_parsed_module.2 with
+  | .error _ => IO.println "FAIL"
+  | .ok parsed_module => do
+    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
+    let f := System.mkFilePath ["/tmp", "mtob.59.wasm"]
+    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
+    h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/mtob.59.wasm"
 
   let i := "(module
         (func (param $x_one i32) (param $three i32) (param $y_one i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))
@@ -197,10 +222,10 @@ def main : IO Unit := do
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/mtob.91.wasm"
     let f := System.mkFilePath ["/tmp", "mtob.91.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/mtob.91.wasm"
 
 
   let i := "(module
@@ -214,10 +239,10 @@ def main : IO Unit := do
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/mtob.47.wasm"
     let f := System.mkFilePath ["/tmp", "mtob.47.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/mtob.47.wasm"
 
   -- NAKED CONST IS NOT IMPLEMENTED YET: https://zulip.yatima.io/#narrow/stream/20-meta/topic/WAST.20pair.20prog/near/32237
   -- let i := "(module
@@ -245,10 +270,10 @@ def main : IO Unit := do
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/mtob.41.wasm"
     let f := System.mkFilePath ["/tmp", "mtob.41.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/mtob.41.wasm"
 
   let i := "(module
     (func (param $x i32))
@@ -260,10 +285,10 @@ def main : IO Unit := do
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/mtob.40.wasm"
     let f := System.mkFilePath ["/tmp", "mtob.40.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/mtob.40.wasm"
 
   let i := "(module
     ( func )
@@ -275,15 +300,16 @@ def main : IO Unit := do
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/mtob.24.wasm"
     let f := System.mkFilePath ["/tmp", "mtob.24.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/mtob.24.wasm"
+
   IO.println "* * *"
 
   -- TODO: pack more ascii into the easter egg with i64
   let i := "(module
-    (func
+    (func $main (export \"main\")
       (param $x i32)
       (param i32)
       (result i32)
@@ -298,14 +324,16 @@ def main : IO Unit := do
   -- unnamed param should have id 1
   IO.println s!"{i} is represented as:"
   let o_parsed_module ← parseTestP moduleP i
+  let something_special_module := o_parsed_module -- We'll run it with Engine in a bit
   match o_parsed_module.2 with
   | .error _ => IO.println "FAIL"
   | .ok parsed_module => do
     IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    IO.println "It's recorded to disk at /tmp/something.special.wasm"
     let f := System.mkFilePath ["/tmp", "something.special.wasm"]
     let h ← IO.FS.Handle.mk f IO.FS.Mode.write
     h.write $ mtob parsed_module
+    IO.println "It's recorded to disk at /tmp/something.special.wasm"
+
   IO.println "* * *"
 
   -- LEB128 TESTS
@@ -365,6 +393,29 @@ def main : IO Unit := do
   IO.println s!"{uLeb128 9000} should be 70, 168"
   IO.println s!"{sLeb128 8787} should be 211, 196, 00"
   IO.println s!"= = END OF SIGNED LEB128 TEST! = ="
+
+
+  match something_special_module.2 with
+  | .error _ => IO.println s!"THERE IS A BUG IN RUNTIME TEST"
+  | .ok m => do
+    IO.println s!"!!!!!!!!!!!! DEMO OF WASM LEAN RUNTIME WOW !!!!!!!!!!!!!"
+    IO.println s!"RUNNING FUNCTION `main` FROM A MODULE WITH REPRESENTATION:\n{m}"
+    let store := mkStore m
+    let ofid := fidByName store "main"
+    let uni_num_zero := NumUniT.i $ ConstInt.mk 32 0
+    let se_zero := StackEntry.num uni_num_zero
+    IO.println $ match ofid with
+    | .none => s!"THERE IS NO FUNCTION CALLED `main`"
+    | .some fid =>
+      let eres := run store fid $ Stack.mk [se_zero, se_zero]
+      match eres with
+      | .ok stack2 => match stack2.es with
+        | x :: _ => match x with
+          | .num universal_number => match universal_number with
+            | .i i => s!"!!!!!!!!!!!!!! SUCCESS !!!!!!!!!!!!!!!!\n{i}"
+            | _ => "FAIL"
+        | _ => "UNEXPECTED RESULT"
+      | .error ee => s!"FAILED TO RUN `main` CORRECTLY: {ee}"
 
   let mut x := 0
   x := 1

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -51,8 +51,8 @@ def extractTypes (m : Module) : ByteArray :=
     let header := ByteArray.mk #[0x60, params.length.toUInt8]
     let res := params.foldl Append.append header
     res ++ (match x.result with --TODO: figure out and support multi-output functions
-    | .none => b 0x00
-    | .some t => ByteArray.mk #[1, ttoi t]
+    | List.nil => b 0x00
+    | ts => uLeb128 ts.length ++ flatten (ts.map $ b ∘ ttoi)
     )
   sigs.foldl
     Append.append $
@@ -174,7 +174,7 @@ def indexFuncs (fs : List Func) : List (Nat × Func) :=
   let go (acc : List (Nat × Func)) (f : Func) :=
     match acc with
     | j :: _ => (j.1, f) :: acc
-    | [] => (0, f) :: acc
+    | [] => [(0, f)]
   (fs.foldl go []).reverse
 
 def encodeLocal (l : Nat × LocalName) : ByteArray :=
@@ -213,14 +213,16 @@ def nMkStr (x : String) : ByteArray :=
   uLeb128 x.length ++ x.toUTF8
 
 def extractExports (m : Module) : ByteArray :=
-  let header := b 0x07
-  let extractExport := fun f => match f.2.export_ with
-    | .some x => nMkStr x ++ b 0x00 ++ uLeb128 f.1
-    | .none => b0
-  let fs := indexFuncs ∘ m.func.filter $ fun f => match f.export_ with
-    | .some _ => true
-    | .none => false
-  header ++ (lindex $ mkVec fs extractExport)
+  let exports := m.func.filter (fun f => Option.toBool f.export_)
+  if exports.isEmpty then
+    let header := b 0x07
+    let extractExport := fun f => match f.2.export_ with
+      | .some x => nMkStr x ++ b 0x00 ++ uLeb128 f.1
+      | .none => b0
+    let fs := indexFuncs ∘ m.func.filter $ fun f => Option.toBool f.export_
+    header ++ (lindex $ mkVec fs extractExport)
+  else
+    b0
 
 def mtob (m : Module) : ByteArray :=
   magic ++

--- a/Wasm/Engine.lean
+++ b/Wasm/Engine.lean
@@ -1,0 +1,174 @@
+import Wasm.Wast.Code
+import Wasm.Wast.Num
+import YatimaStdLib
+
+open Wasm.Wast.Code
+open Wasm.Wast.Code.Func
+open Wasm.Wast.Code.Local
+open Wasm.Wast.Code.Module
+open Wasm.Wast.Code.Operation
+open Wasm.Wast.Code.Type'
+open Wasm.Wast.Num.Uni
+open Cached
+
+namespace Wasm.Engine
+
+/- Likely unused hehe -/
+-- structure Label where
+--   frame : Int
+--   kind : Byte --<-- this is an index of a 'continuation'
+
+inductive EngineErrors where
+| not_enough_stuff_on_stack
+| param_type_incompatible
+| local_with_given_name_missing : String → EngineErrors
+| local_with_given_id_missing : Nat → EngineErrors
+| function_not_found
+| other -- JACKAL
+
+instance : ToString EngineErrors where
+  toString x := match x with
+  | .not_enough_stuff_on_stack => "not enough stuff on stack"
+  | .param_type_incompatible => "param type incompatible"
+  | .local_with_given_id_missing i => s!"local #{i} not found"
+  | .local_with_given_name_missing n => s!"local ``{n}'' not found"
+  | .function_not_found => s!"function not found"
+  | .other => "non-specified"
+
+instance : Inhabited EngineErrors where
+  default := .other
+
+inductive StackEntry where
+| num : NumUniT → StackEntry
+
+/- TODO: I forgot what sort of other stacks are in standard lol, but ok. -/
+structure Stack where
+  es : List StackEntry
+
+/- TODO: Functions for Stack? -/
+
+/- TODO: This will eventually depend on ModuleInstance! -/
+structure FunctionInstance (x : Module) where
+  name : Option String
+  export_ : Option String
+  params : List Local
+  result : List Type'
+  locals : List Local -- These locals are indexed.
+  index : Nat
+  ops : List Operation
+
+
+/- TODO: Unify this with Bytes.indexFuncs -/
+def instantiateFs (m : Module) : List (FunctionInstance m) :=
+  let go acc f :=
+    let pl := reindexParamsAndLocals f
+    let fi := FunctionInstance.mk f.name
+                                  f.export_
+                                  pl.1
+                                  f.result
+                                  pl.2
+                                  0
+                                  f.ops
+    match acc with
+    | [] => [fi]
+    | x :: _ => {fi with index := x.index + 1} :: acc
+  (m.func.foldl go []).reverse
+
+structure Store (m : Module) where
+  func : List (FunctionInstance m)
+
+def mkStore (m : Module) : Store m :=
+  Store.mk $ instantiateFs m
+
+def funcByName (s : Store m) (x : String) : Option $ FunctionInstance m :=
+  match s.func.filter (fun f => f.name == .some x) with
+  | y :: [] => .some y
+  | _ => .none
+
+def fidByName (s : Store m) (x : String) : Option Nat :=
+  funcByName s x >>= pure ∘ FunctionInstance.index
+
+def paramTypecheck (x : Local) (y : StackEntry) :=
+  let t := localToType x
+  match y with
+  | .num nn => match nn with
+    | .i n => match t with
+      | .i 32 => n.bs == 32
+      | .i 64 => n.bs == 64
+      | _ => false
+    | .f n => match t with
+      | .f 32 => n.bs == 32
+      | .f 64 => n.bs == 64
+      | _ => false
+
+def findLocal (ls : List (Option String × Option StackEntry))
+              (x : String)
+              : Option StackEntry :=
+  match ls.filter (fun se => .some x == se.1) with
+  | y :: [] => y.2
+  | _ => .none
+
+mutual
+  /- TODO: Support multi-output functions. -/
+  partial def getSO (locals : List (Option String × Option StackEntry))
+                    (stack : List StackEntry)
+                    : Get' → Except EngineErrors (List StackEntry × StackEntry)
+    | .from_stack => match stack with
+      | [] => .error .not_enough_stuff_on_stack
+      | s :: rest => .ok (rest, s)
+    | .from_operation o => runOp locals stack o
+    -- TODO: names are erased in production. See what do we want to do with this code path.
+    | .by_name n => match findLocal locals n.name with
+      | .none => .error $ .local_with_given_name_missing n.name
+      | .some l => .ok (stack, l)
+    | .by_index i => match locals.get? i.index with
+      | .some (_, .some se)  => .ok (stack, se)
+      | _ => .error $ .local_with_given_id_missing i.index
+    | .i_const i => .ok $ (stack, .num $ NumUniT.i i)
+    | .f_const f => .ok $ (stack, .num $ NumUniT.f f)
+
+  -- TODO: there's a StateT somewhere here. Just sayin'
+  partial def runOp (locals : List (Option String × Option StackEntry))
+                    (stack : List StackEntry)
+                    : Operation
+                    → Except EngineErrors (List StackEntry × StackEntry)
+    | .add add' => match add' with | .add _t g0 g1 => do
+      let (stack', operand0) ← getSO locals stack g0
+      let (stack1, operand1) ← getSO locals stack' g1
+      let res ← match operand0, operand1 with
+      | .num n0, .num n1 => match n0, n1 with
+        | .i ⟨b0, i0⟩, .i ⟨_b1, i1⟩ => pure $ .num $ .i ⟨b0, i0 + i1⟩ -- TODO: check bitsize and overflow!
+        | .f ⟨b0, f0⟩, .f ⟨_b1, f1⟩ => pure $ .num $ .f ⟨b0, f0 + f1⟩ -- check bitsize and overflow!
+        | _, _ => throw .param_type_incompatible
+      pure (res :: stack1, res)
+end
+
+def runDo (_s : Store m)
+          (f : FunctionInstance m)
+          (σ : Stack)
+          : Except EngineErrors Stack := do
+  let bite acc x :=
+    match acc with
+    | .error _ => acc
+    | .ok cont => match cont.1.es with
+      | [] => .error .not_enough_stuff_on_stack -- TODO: Better errors lol lol
+      | y :: rest => if paramTypecheck x y then
+        .ok (Stack.mk rest, y :: cont.2)
+      else
+        .error .param_type_incompatible
+  let pσ ← f.params.foldl bite $ .ok (σ, [])
+  let locals := (f.params ++ f.locals).map $
+    fun l => match l with
+      | .name ll => (.some ll.name, pσ.2.get? ll.index)
+      | .index ll => (.none, pσ.2.get? ll.index)
+  let go (oσ : Except EngineErrors Stack) (x : Operation)
+         : Except EngineErrors Stack := do
+    let stack ← oσ
+    let naked_stack_and_result ← runOp locals (Stack.es stack) x
+    pure $ Stack.mk naked_stack_and_result.1
+  f.ops.foldl go $ .ok $ Stack.mk pσ.2
+
+def run (s : Store m) (fid : Nat) (σ : Stack) : Except EngineErrors Stack :=
+  match s.func.get? fid with
+  | .none => .error .function_not_found
+  | .some f => runDo s f σ

--- a/Wasm/Runtime.lean
+++ b/Wasm/Runtime.lean
@@ -1,0 +1,1 @@
+namespace Wasm.Runtime

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -422,4 +422,20 @@ instance : ToString ConstFloat where
 
 end Num.Float
 
+namespace Uni
+
+open NumType
+open Num.Int
+open Num.Float
+
+inductive NumUniT where
+-- | i32 : NumType.int 32 → ConstInt → NumUniT
+-- | i64 : NumType.int 64 → ConstInt → NumUniT
+-- | f32 : NumType.float 32 → ConstFloat → NumUniT
+-- | f64 : NumType.float 64 → ConstFloat → NumUniT
+| i : ConstInt → NumUniT
+| f : ConstFloat → NumUniT
+
+end Uni
+
 end Wasm.Wast.Num

--- a/Wasm/Wast/Parser/Common.lean
+++ b/Wasm/Wast/Parser/Common.lean
@@ -10,10 +10,10 @@ open Megaparsec.Errors
 namespace Wasm.Wast.Parser.Common
 
 def ignoreP : Parsec Char String Unit Unit :=
-  void $ some' $ oneOf " \t\n".data
+  discard $ some' $ oneOf " \t\n".data
 
 def owP : Parsec Char String Unit Unit :=
-  void $ option' $ some' $ oneOf " \t\n".data
+  discard $ many' $ oneOf " \t\n".data
 
 def specials : List Char := " ()".data
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -13,7 +13,7 @@ require YatimaStdLib from git
   "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "b6b2ff88d06b3c200b9b81aa0a0ac952c35e4631"
 
 require Megaparsec from git
-  "https://github.com/yatima-inc/Megaparsec.lean.git/" @ "eb89cf8c50dcecc454639fb5c9e2f6444aa37d21"
+  "https://github.com/yatima-inc/Megaparsec.lean.git/" @ "50f9beb2af165f5736155d30cdda2774784b677b"
 
 @[default_target]
 lean_exe wasm {


### PR DESCRIPTION
Solution:

 - Learn how other runtimes implement stuff (particularly, wazero, because Go code is actually easy to read).
 - See that they run internal representation of the code rather than streaming it.
 - Mirror abstract func expression into instantiated function data type. This data type guarantees that locals and functions are indexed.
 - Implement Stack: https://zulip.yatima.io/#narrow/stream/20-meta/topic/WAST.20pair.20prog/near/34867 no idea why is it implemented like this, but probably there are other stacks in wasm runtimes.
 - Implement Store. Just support functions store. Make a simple way to make a store with mkStore function.
 - Implement function dispatching with support of names. NB!!! Names are tags right, not exports !!!NB. We don't look up exports yet, but we should. #19
 - Write a function that typechecks locals against stack entry.
 - Write a way to read stack entries off the stack! Call it `bite`. Because we're kinda biting stuff off the stack. Idk, I'm coding under time pressure here, give me a break.
 - Finally, implement functions that run a bunch of operations.
   - Demo it in the final section of Main.lean.