### PR TITLE
[#17] Implement simple branching

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -200,6 +200,18 @@ def main : IO Unit := do
   IO.println "* * *"
 
   IO.println "* * *"
+  let i := "block "
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP blockP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "(block (result i32) (i32.const 1) end)"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP opP i
+  IO.println "* * *"
+
+  IO.println "* * *"
   let i := "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))"
   -- unnamed param should have id 1
   IO.println s!"{i} is represented as:"
@@ -376,7 +388,7 @@ def main : IO Unit := do
       (param i32)
       (result i32 i32) (result i32 i32)
 
-      (i32.const 1)
+      (block (result i32) (i32.const 1))
       (nop)
       (i32.add
         (i32.const 1499550000)

--- a/Main.lean
+++ b/Main.lean
@@ -200,15 +200,15 @@ def main : IO Unit := do
   IO.println "* * *"
 
   IO.println "* * *"
-  let i := "block "
-  IO.println s!"{i} is represented as:"
-  void $ parseTestP blockP i
-  IO.println "* * *"
-
-  IO.println "* * *"
   let i := "(block (result i32) (i32.const 1) end)"
   IO.println s!"{i} is represented as:"
   void $ parseTestP opP i
+  IO.println "* * *"
+
+  IO.println "* * *"
+  let i := "if (result i32) then (i32.const 42) else (i32.const 9)"
+  IO.println s!"{i} is represented as:"
+  void $ parseTestP ifP i
   IO.println "* * *"
 
   IO.println "* * *"
@@ -388,8 +388,8 @@ def main : IO Unit := do
       (param i32)
       (result i32 i32) (result i32 i32)
 
-      (block (result i32) (i32.const 1))
-      (nop)
+      (block (result i32) (i32.const 0))
+      (if (result i32) then (i32.const 8) else (i32.const 2))
       (i32.add
         (i32.const 1499550000)
         (i32.add (i32.const 9000) (i32.const 17))

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -103,10 +103,10 @@ mutual
       b 0x03 ++ bts ++ lindex obs ++ b 0x0b
     | .if ts thens elses =>
       let bts := flatten $ ts.map (b ∘ ttoi)
-      let bth := b thens.length.toUInt8 ++ flatten (thens.map extractOp)
+      let bth := uLeb128 thens.length ++ flatten (thens.map extractOp)
       let belse := if elses.isEmpty then b0
         else
-          let bel := b elses.length.toUInt8 ++ flatten (elses.map extractOp)
+          let bel := uLeb128 elses.length ++ flatten (elses.map extractOp)
           b 0x05 ++ lindex bel
       b 0x04 ++ bts ++ lindex (bth ++ belse) ++ b 0x0b
 
@@ -118,7 +118,6 @@ def extractOps (ops : List Operation) : List ByteArray :=
 
 def extractFuncs (fs : List Func) : ByteArray :=
   let header := b 0x0a -- ← here we'll add the whole size of the section.
-  let fn := b $ fs.length.toUInt8
   let fbs := flatten $ fs.map (fun x =>
     -- ← now for each function's code section, we'll add its size after we do all the other
     --   computations.
@@ -131,7 +130,7 @@ def extractFuncs (fs : List Func) : ByteArray :=
 
     lindex $ locals ++ obs ++ b 0x0b
   )
-  header ++ (lindex $ fn ++ fbs)
+  header ++ (lindex $ uLeb128 fs.length ++ fbs)
 
 -- TODO
 def extractModName (_ : Module) : ByteArray := b0

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -93,7 +93,7 @@ mutual
       extractGet' g1 ++ extractGet' g2 ++ extractAdd t
     | .block ts ops =>
       let bts := flatten $ ts.map (b ∘ ttoi)
-      let obs := bts ++ b ops.length.toUInt8 ++ flatten (ops.map extractOp)
+      let obs := bts ++ uLeb128 ops.length ++ flatten (ops.map extractOp)
       b 0x02 ++ bts ++ lindex obs ++ b 0x0b
 end
 

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -95,6 +95,11 @@ mutual
       let bts := flatten $ ts.map (b ∘ ttoi)
       let obs := bts ++ uLeb128 ops.length ++ flatten (ops.map extractOp)
       b 0x02 ++ bts ++ lindex obs ++ b 0x0b
+    | .loop ts ops =>
+      let bts := flatten $ ts.map (b ∘ ttoi)
+      let obs := bts ++ uLeb128 ops.length ++ flatten (ops.map extractOp)
+      b 0x03 ++ bts ++ lindex obs ++ b 0x0b
+
 end
 
 def extractOps (ops : List Operation) : List ByteArray :=

--- a/Wasm/Engine.lean
+++ b/Wasm/Engine.lean
@@ -171,6 +171,12 @@ mutual
       if resultsTypecheck ts es'
         then pure $ es' ++ stack
         else throw .stack_incompatible_with_results
+    | .loop ts ops => do
+      let go σ op := do runOp locals (←σ) op
+      let es' ← ops.foldl go $ pure []
+      if resultsTypecheck ts es'
+        then pure $ es' ++ stack
+        else throw .stack_incompatible_with_results
 end
 
 def runDo (_s : Store m)

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -64,6 +64,15 @@ instance : ToString (Get α) where
 end Get
 open Get
 
+namespace Label
+
+/- Likely unused hehe -/
+structure Label where
+  frame : Int
+  kind : Byte --<-- this is an index of a 'continuation'
+
+end Label
+
 
 /- TODO: Instructions are rigid WAT objects. If we choose to only support
 S-Expressions at this point, we don't need this concept. -/
@@ -81,12 +90,14 @@ mutual
   | by_name : Local → Get'
   | by_index : Local → Get'
 
+-- TODO: add support for function type indexes for blocktypes
 -- TODO: replace "NumUniT" with something supporting ConstVec when implemented
 -- TODO: generalise Consts the same way Get is generalised so that i32.const can't be populated with ConstFloat!
   inductive Operation where
   | nop
   | const : Type' → NumUniT → Operation
   | add : Type' → Get' → Get' → Operation
+  | block : List Type' → List Operation → Operation
 end
 
 mutual
@@ -103,6 +114,7 @@ mutual
     | .nop => "(Operation.nop)"
     | .const t n => s!"(Operation.const {t} {n})"
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
+    | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
 
 end
 
@@ -145,21 +157,6 @@ instance : ToString Module where
 
 end Module
 
-namespace Label
-
-/- Likely unused hehe -/
-structure Label where
-  frame : Int
-  kind : Byte --<-- this is an index of a 'continuation'
-
-end Label
-
-namespace Block
-end Block
-
-
-namespace Loop
-end Loop
 
 end AST
 end Wasm.Wast.AST

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -98,6 +98,7 @@ mutual
   | const : Type' → NumUniT → Operation
   | add : Type' → Get' → Get' → Operation
   | block : List Type' → List Operation → Operation
+  | loop : List Type' → List Operation → Operation
 end
 
 mutual
@@ -115,6 +116,7 @@ mutual
     | .const t n => s!"(Operation.const {t} {n})"
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
+    | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
 
 end
 

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -99,6 +99,7 @@ mutual
   | add : Type' → Get' → Get' → Operation
   | block : List Type' → List Operation → Operation
   | loop : List Type' → List Operation → Operation
+  | if : List Type' → List Operation → List Operation → Operation
 end
 
 mutual
@@ -117,6 +118,7 @@ mutual
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
     | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
+    | .if ts thens elses => s!"(Operation.if {ts} {thens.map operationToString} {elses.map operationToString})"
 
 end
 

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -86,7 +86,7 @@ private def constP : Parsec Char String Unit Operation := do
 
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
-      nopP <|> constP <|> addP <|> blockP
+      nopP <|> constP <|> addP <|> blockP <|> loopP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP
@@ -97,6 +97,13 @@ private def constP : Parsec Char String Unit Operation := do
     let ops ← opsP
     owP <* option' (string "end")
     pure $ .block ts ops
+
+  partial def loopP : Parsec Char String Unit Operation := do
+    string "loop" *> ignoreP
+    let ts ← brResultsP
+    let ops ← opsP
+    owP <* option' (string "end")
+    pure $ .loop ts ops
 
   partial def addP : Parsec Char String Unit Operation := do
     -- TODO: we'll use ps when we'll add more types into `Type'`.

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -86,7 +86,7 @@ private def constP : Parsec Char String Unit Operation := do
 
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
-      nopP <|> constP <|> addP <|> blockP <|> loopP
+      nopP <|> constP <|> addP <|> blockP <|> loopP <|> ifP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP
@@ -104,6 +104,16 @@ private def constP : Parsec Char String Unit Operation := do
     let ops ← opsP
     owP <* option' (string "end")
     pure $ .loop ts ops
+
+  partial def ifP : Parsec Char String Unit Operation := do
+    string "if" *> ignoreP
+    let ts ← brResultsP
+    string "then" *> ignoreP
+    let thens ← opsP
+    string "else" *> ignoreP
+    let elses ← opsP
+    owP <* option' (string "end")
+    pure $ .if ts thens elses
 
   partial def addP : Parsec Char String Unit Operation := do
     -- TODO: we'll use ps when we'll add more types into `Type'`.

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,7 +1,9 @@
 import Lake
 open Lake DSL
 
-package Wasm
+package Wasm {
+  precompileModules := true
+}
 
 @[default_target]
 lean_lib Wasm


### PR DESCRIPTION
Problem: branching is done through structured instructions like `block` and branches targeting them, of which we have none.

Solution: implemented support for the `block` and `loop` instructions. This isn't _branching_ yet, strictly speaking, but it's necessary for it. Also added support for `if`, which _is_ branching, if in the most primitive of senses.

Follows #17