### PR TITLE
[#30] Support br and br_if instructions

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -418,7 +418,7 @@ def main : IO Unit := do
     let store := mkStore m
     let ofid := fidByName store "main"
     let uni_num_zero := NumUniT.i $ ConstInt.mk 32 0
-    let se_zero := StackEntry.num uni_num_zero
+    let se_zero := StackEntry.StackEntry.num uni_num_zero
     IO.println $ match ofid with
     | .none => s!"THERE IS NO FUNCTION CALLED `main`"
     | .some fid =>

--- a/Main.lean
+++ b/Main.lean
@@ -388,8 +388,7 @@ def main : IO Unit := do
       (param i32)
       (result i32 i32)
 
-      (block (result i32) (i32.const 0))
-      (if (result i32) then (i32.const 8) else (i32.const 2))
+      (block (result i32) (i32.const 3) (i32.add (br 0) (i32.const 9)))
       (i32.add
         (i32.const 1499550000)
         (i32.add (i32.const 9000) (i32.const 17))

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -109,6 +109,8 @@ mutual
           let bel := uLeb128 elses.length ++ flatten (elses.map extractOp)
           b 0x05 ++ lindex bel
       b 0x04 ++ bts ++ lindex (bth ++ belse) ++ b 0x0b
+    | .br li => b 0x0c ++ sLeb128 li
+    | .br_if li => b 0x0d ++ sLeb128 li
 
 
 end

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -100,8 +100,11 @@ mutual
   | by_index : Local → Get'
 
 -- TODO: add support for function type indexes for blocktypes
--- TODO: replace "NumUniT" with something supporting ConstVec when implemented
--- TODO: generalise Consts the same way Get is generalised so that i32.const can't be populated with ConstFloat!
+-- TODO: branching ops can produce and consume operands themselves,
+-- e.g. `(br 0 (i32.const 2))`. Right now we don't support it, but should we?
+-- TODO: replace `NumUniT` with something supporting `ConstVec` when implemented
+-- TODO: generalise Consts the same way Get is generalised so that `i32.const`
+-- can't be populated with `ConstFloat`!
   inductive Operation where
   | nop
   | const : Type' → NumUniT → Operation
@@ -109,6 +112,8 @@ mutual
   | block : List Type' → List Operation → Operation
   | loop : List Type' → List Operation → Operation
   | if : List Type' → List Operation → List Operation → Operation
+  | br : LabelIndex → Operation
+  | br_if : LabelIndex → Operation
 end
 
 mutual
@@ -128,6 +133,8 @@ mutual
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
     | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
     | .if ts thens elses => s!"(Operation.if {ts} {thens.map operationToString} {elses.map operationToString})"
+    | .br li => s!"(Operation.br {li})"
+    | .br_if li => s!"(Operation.br_if {li})"
 
 end
 

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -45,6 +45,24 @@ instance : ToString Local where
 end Local
 open Local
 
+namespace LabelIndex
+
+structure LabelIndex where
+  li : Nat
+  deriving Repr, DecidableEq
+
+instance : Coe Nat LabelIndex where
+  coe n := ⟨n⟩
+
+instance : Coe LabelIndex Nat where
+  coe | ⟨n⟩ => n
+
+instance : ToString LabelIndex where
+  toString | ⟨n⟩ => s!"(LabelIndex {n})"
+
+end LabelIndex
+open LabelIndex
+
 
 namespace Get
 
@@ -63,15 +81,6 @@ instance : ToString (Get α) where
 
 end Get
 open Get
-
-namespace Label
-
-/- Likely unused hehe -/
-structure Label where
-  frame : Int
-  kind : Byte --<-- this is an index of a 'continuation'
-
-end Label
 
 
 /- TODO: Instructions are rigid WAT objects. If we choose to only support
@@ -103,7 +112,7 @@ mutual
 end
 
 mutual
-  partial def getToString (x : Get') : String :=
+  private partial def getToString (x : Get') : String :=
     "(Get'" ++ (
       match x with
       | .from_stack => ".from_stack"
@@ -112,7 +121,7 @@ mutual
       | .by_index i => ".by_index " ++ toString i
     ) ++ ")"
 
-  partial def operationToString : Operation → String
+  private partial def operationToString : Operation → String
     | .nop => "(Operation.nop)"
     | .const t n => s!"(Operation.const {t} {n})"
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -18,6 +18,7 @@ open MonadParsec
 open Wasm.Wast.AST
 open Wasm.Wast.Name
 open Wasm.Wast.Parser.Common
+open Wasm.Wast.Num.Num.Nat
 open Wasm.Wast.Num.Num.Int
 open Wasm.Wast.Num.Num.Float
 open Wasm.Wast.Num.Uni
@@ -78,6 +79,16 @@ private def constP : Parsec Char String Unit Operation := do
   let x ← numUniTP
   pure $ Operation.const (numUniType x) x
 
+private def brP : Parsec Char String Unit Operation := do
+  string "br" *> ignoreP
+  let idx ← hexP <|> decimalP
+  pure $ .br ⟨idx⟩
+
+private def brifP : Parsec Char String Unit Operation := do
+  string "br_if" *> ignoreP
+  let idx ← hexP <|> decimalP
+  pure $ .br ⟨idx⟩
+
  mutual
 
   partial def get'ViaGetP (α  : Type') : Parsec Char String Unit Get' :=
@@ -86,7 +97,9 @@ private def constP : Parsec Char String Unit Operation := do
 
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
-      nopP <|> constP <|> addP <|> blockP <|> loopP <|> ifP
+      nopP <|> constP <|> addP <|>
+        blockP <|> loopP <|> ifP <|>
+        brP <|> brifP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP


### PR DESCRIPTION
Problem: we only have very primitive support for branching, in the form of `if` and `block`.

Solution: added support (parse, engine, binary) for `br` and `br_if`, together with support for handling continuations these ops create.

Closes #30