### PR TITLE
[#32] Fix initial stack duplicating params

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -386,7 +386,7 @@ def main : IO Unit := do
     (func $main (export \"main\")
       (param $x i32)
       (param i32)
-      (result i32 i32) (result i32 i32)
+      (result i32 i32)
 
       (block (result i32) (i32.const 0))
       (if (result i32) then (i32.const 8) else (i32.const 2))

--- a/Wasm/Engine.lean
+++ b/Wasm/Engine.lean
@@ -51,6 +51,9 @@ instance : ToString StackEntry where
 structure Stack where
   es : List StackEntry
 
+instance : ToString Stack where
+  toString | ⟨es⟩ => s!"(Stack {es})"
+
 /- TODO: Functions for Stack? -/
 
 /- TODO: This will eventually depend on ModuleInstance! -/
@@ -203,7 +206,7 @@ def runDo (_s : Store m)
   let locals := (f.params ++ f.locals).map
     fun l => (l.name, pσ.2.get? l.index)
   let go oσ x:= do Stack.mk <$> runOp locals (←oσ).es x
-  f.ops.foldl go $ .ok $ Stack.mk pσ.2
+  f.ops.foldl go $ .ok pσ.1
 
 -- This is sort of a debug function, returning the full resulting stack instead
 -- of just the values specified in the result fields.


### PR DESCRIPTION
Problem: the initial stack when running a module currently not only initialises locals/parameters, but also duplicates the entire parameter set on stack, as well as losing any real initial stack.

Solution: fixed the typo that was responsible.

Closes #32 