### PR TITLE
Support all numerical instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 result*
 build/
 lean_packages/
+lake-packages/

--- a/Main.lean
+++ b/Main.lean
@@ -144,7 +144,7 @@ def main : IO Unit := do
 
   IO.println "* * *"
   IO.println "i32.add (i32.const 42) is represented as:"
-  void $ parseTestP addP "i32.add (i32.const 42)"
+  void $ parseTestP (iBinopP "add" .add) "i32.add (i32.const 42)"
   IO.println "* * *"
 
   IO.println "* * *"

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -69,6 +69,74 @@ def extractFuncIds (m : Module) : ByteArray :=
 
 -- TODO: maybe calculate the opcodes instead of having lots of lookup subtables?
 -- def extractIBinOp (α : Type') (offset : UInt8)
+def extractEqz (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x45
+  | .i 64 => 0x50
+  | _ => unreachable!
+
+def extractEq (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x46
+  | .i 64 => 0x51
+  | .f 32 => 0x5b
+  | .f 64 => 0x61
+
+def extractNe (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x47
+  | .i 64 => 0x52
+  | .f 32 => 0x5c
+  | .f 64 => 0x62
+
+def extractLts (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x48
+  | .i 64 => 0x53
+  | _ => unreachable!
+
+def extractLtu (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x49
+  | .i 64 => 0x54
+  | _ => unreachable!
+
+def extractGts (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x4a
+  | .i 64 => 0x55
+  | _ => unreachable!
+
+def extractGtu (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x4b
+  | .i 64 => 0x56
+  | _ => unreachable!
+
+def extractLes (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x4c
+  | .i 64 => 0x57
+  | _ => unreachable!
+
+def extractLeu (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x4d
+  | .i 64 => 0x58
+  | _ => unreachable!
+
+def extractGes (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x4e
+  | .i 64 => 0x59
+  | _ => unreachable!
+
+def extractGeu (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x4f
+  | .i 64 => 0x5a
+  | _ => unreachable!
+
 def extractClz (α : Type') : ByteArray :=
   b $ match α with
   | .i 32 => 0x67
@@ -196,6 +264,17 @@ mutual
     | .const (.i 32) (.i ci) => b 0x41 ++ sLeb128 ci.val
     | .const (.i 64) (.i ci) => b 0x42 ++ sLeb128 ci.val
     | .const _ _ => sorry -- TODO: float binary encoding
+    | .eqz    t g => extractGet' g ++ extractEqz t
+    | .eq t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractEq t
+    | .ne t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractNe t
+    | .lt_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLtu t
+    | .lt_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLts t
+    | .gt_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGtu t
+    | .gt_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGts t
+    | .le_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLeu t
+    | .le_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLes t
+    | .ge_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGeu t
+    | .ge_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGes t
     | .clz    t g => extractGet' g ++ extractClz t
     | .ctz    t g => extractGet' g ++ extractCtz t
     | .popcnt t g => extractGet' g ++ extractPopcnt t

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -74,6 +74,94 @@ def extractAdd (α : Type') : ByteArray :=
   | .f 32 => 0x92
   | .f 64 => 0xa0
 
+-- TODO: maybe calculate the opcodes instead of having lots of lookup subtables?
+-- def extractIBinOp (α : Type') (offset : UInt8)
+def extractSub (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x6b
+  | .i 64 => 0x7d
+  | .f 32 => 0x93
+  | .f 64 => 0xa1
+
+def extractMul (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x6c
+  | .i 64 => 0x7e
+  | .f 32 => 0x94
+  | .f 64 => 0xa2
+
+def extractDivS (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x6d
+  | .i 64 => 0x7f
+  | _ => unreachable!
+
+def extractDivU (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x6e
+  | .i 64 => 0x80
+  | _ => unreachable!
+
+def extractRemS (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x6f
+  | .i 64 => 0x81
+  | _ => unreachable!
+
+def extractRemU (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x70
+  | .i 64 => 0x82
+  | _ => unreachable!
+
+def extractAnd (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x71
+  | .i 64 => 0x83
+  | _ => unreachable!
+
+def extractOr (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x72
+  | .i 64 => 0x84
+  | _ => unreachable!
+
+def extractXor (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x73
+  | .i 64 => 0x85
+  | _ => unreachable!
+
+def extractShl (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x74
+  | .i 64 => 0x86
+  | _ => unreachable!
+
+def extractShrS (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x75
+  | .i 64 => 0x87
+  | _ => unreachable!
+
+def extractShrU (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x76
+  | .i 64 => 0x88
+  | _ => unreachable!
+
+def extractRotl (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x77
+  | .i 64 => 0x89
+  | _ => unreachable!
+
+def extractRotr (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x78
+  | .i 64 => 0x8a
+  | _ => unreachable!
+
 mutual
   -- https://coolbutuseless.github.io/2022/07/29/toy-wasm-interpreter-in-base-r/
   partial def extractGet' (x : Get') : ByteArray :=
@@ -90,9 +178,21 @@ mutual
     | .const (.i 32) (.i ci) => b 0x41 ++ sLeb128 ci.val
     | .const (.i 64) (.i ci) => b 0x42 ++ sLeb128 ci.val
     | .const _ _ => sorry -- TODO: float binary encoding
-    | .add t g1 g2 =>
-      -- Enter stackman
-      extractGet' g1 ++ extractGet' g2 ++ extractAdd t
+    | .add t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractAdd t
+    | .sub t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractSub t
+    | .mul t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractMul t
+    | .div_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractDivS t
+    | .div_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractDivU t
+    | .rem_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractRemS t
+    | .rem_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractRemU t
+    | .and t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractAnd t
+    | .or  t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractOr  t
+    | .xor t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractXor t
+    | .shl t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractShl t
+    | .shr_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractShrU t
+    | .shr_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractShrS t
+    | .rotl t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractRotl t
+    | .rotr t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractRotr t
     | .block ts ops =>
       let bts := flatten $ ts.map (b ∘ ttoi)
       let obs := bts ++ uLeb128 ops.length ++ flatten (ops.map extractOp)

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -67,6 +67,26 @@ def extractFuncIds (m : Module) : ByteArray :=
     m.func.foldl (fun acc _x => (acc ++ (b ∘ Nat.toUInt8) acc.data.size)) b0
   b 0x03 ++ uLeb128 funs.data.size ++ funs
 
+-- TODO: maybe calculate the opcodes instead of having lots of lookup subtables?
+-- def extractIBinOp (α : Type') (offset : UInt8)
+def extractClz (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x67
+  | .i 64 => 0x79
+  | _ => unreachable!
+
+def extractCtz (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x68
+  | .i 64 => 0x7a
+  | _ => unreachable!
+
+def extractPopcnt (α : Type') : ByteArray :=
+  b $ match α with
+  | .i 32 => 0x69
+  | .i 64 => 0x7b
+  | _ => unreachable!
+
 def extractAdd (α : Type') : ByteArray :=
   b $ match α with
   | .i 32 => 0x6a
@@ -74,8 +94,6 @@ def extractAdd (α : Type') : ByteArray :=
   | .f 32 => 0x92
   | .f 64 => 0xa0
 
--- TODO: maybe calculate the opcodes instead of having lots of lookup subtables?
--- def extractIBinOp (α : Type') (offset : UInt8)
 def extractSub (α : Type') : ByteArray :=
   b $ match α with
   | .i 32 => 0x6b
@@ -178,6 +196,9 @@ mutual
     | .const (.i 32) (.i ci) => b 0x41 ++ sLeb128 ci.val
     | .const (.i 64) (.i ci) => b 0x42 ++ sLeb128 ci.val
     | .const _ _ => sorry -- TODO: float binary encoding
+    | .clz    t g => extractGet' g ++ extractClz t
+    | .ctz    t g => extractGet' g ++ extractCtz t
+    | .popcnt t g => extractGet' g ++ extractPopcnt t
     | .add t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractAdd t
     | .sub t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractSub t
     | .mul t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractMul t

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -89,6 +89,30 @@ def extractNe (α : Type') : ByteArray :=
   | .f 32 => 0x5c
   | .f 64 => 0x62
 
+def extractLt (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x5d
+  | .f 64 => 0x63
+  | _ => unreachable!
+
+def extractGt (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x5e
+  | .f 64 => 0x64
+  | _ => unreachable!
+
+def extractLe (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x5f
+  | .f 64 => 0x65
+  | _ => unreachable!
+
+def extractGe (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x60
+  | .f 64 => 0x66
+  | _ => unreachable!
+
 def extractLts (α : Type') : ByteArray :=
   b $ match α with
   | .i 32 => 0x48
@@ -175,6 +199,30 @@ def extractMul (α : Type') : ByteArray :=
   | .i 64 => 0x7e
   | .f 32 => 0x94
   | .f 64 => 0xa2
+
+def extractDiv (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x95
+  | .f 64 => 0xa3
+  | _ => unreachable!
+
+def extractMin (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x96
+  | .f 64 => 0xa4
+  | _ => unreachable!
+
+def extractMax (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x97
+  | .f 64 => 0xa5
+  | _ => unreachable!
+
+def extractCopysign (α : Type') : ByteArray :=
+  b $ match α with
+  | .f 32 => 0x98
+  | .f 64 => 0xa6
+  | _ => unreachable!
 
 def extractDivS (α : Type') : ByteArray :=
   b $ match α with
@@ -275,12 +323,19 @@ mutual
     | .le_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLes t
     | .ge_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGeu t
     | .ge_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGes t
+    | .lt t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLt t
+    | .gt t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGt t
+    | .le t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractLe t
+    | .ge t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractGe t
     | .clz    t g => extractGet' g ++ extractClz t
     | .ctz    t g => extractGet' g ++ extractCtz t
     | .popcnt t g => extractGet' g ++ extractPopcnt t
     | .add t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractAdd t
     | .sub t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractSub t
     | .mul t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractMul t
+    | .div t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractDiv t
+    | .min t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractMin t
+    | .max t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractMax t
     | .div_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractDivS t
     | .div_u t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractDivU t
     | .rem_s t g1 g2 => extractGet' g1 ++ extractGet' g2 ++ extractRemS t

--- a/Wasm/Engine.lean
+++ b/Wasm/Engine.lean
@@ -283,6 +283,17 @@ mutual
     match op with
     | .nop => pure ⟨⟩
     | .const _t n => push $ .num n
+    | .eqz _t g => runIUnop g $ (if · = 0 then 1 else 0)
+    | .eq _t g0 g1 => runIBinop g0 g1 (if · = · then 1 else 0)
+    | .ne _t g0 g1 => runIBinop g0 g1 (if · ≠ · then 1 else 0)
+    | .lt_u t  g0 g1 => runIBinop g0 g1 $ unsigned (if · < · then 1 else 0) t
+    | .lt_s _t g0 g1 => runIBinop g0 g1 (if · < · then 1 else 0)
+    | .gt_u t  g0 g1 => runIBinop g0 g1 $ unsigned (if · > · then 1 else 0) t
+    | .gt_s _t g0 g1 => runIBinop g0 g1 (if · > · then 1 else 0)
+    | .le_u t  g0 g1 => runIBinop g0 g1 $ unsigned (if · ≤ · then 1 else 0) t
+    | .le_s _t g0 g1 => runIBinop g0 g1 (if · ≤ · then 1 else 0)
+    | .ge_u t  g0 g1 => runIBinop g0 g1 $ unsigned (if · ≥ · then 1 else 0) t
+    | .ge_s _t g0 g1 => runIBinop g0 g1 (if · ≥ · then 1 else 0)
     | .clz t g => runIUnop g fun i =>
       ((toNBits i $ bitsize t).takeWhile (· = .zero)).length
     | .ctz t g => runIUnop g fun i =>

--- a/Wasm/Leb128.lean
+++ b/Wasm/Leb128.lean
@@ -1,31 +1,6 @@
-import YatimaStdLib
+import YatimaStdLib.Bit
 
 namespace Wasm.Leb128
-
-def bitNot (x : Bit) : Bit :=
-  match x with
-  | .one => .zero
-  | .zero => .one
-
-def onesComplement (xs : List Bit) : List Bit :=
-  xs.map bitNot
-
-def summator (x y : Bit) : (Bit × Bit) :=
-  match (x, y) with
-  | (.one, .one) => (.one, .zero)
-  | (.zero, .one) => (.zero, .one)
-  | (.one, .zero) => (.zero, .one)
-  | (.zero, .zero) => (.zero, .zero)
-
-def plusOne (xs : List Bit) : List Bit :=
-  (xs.foldr (fun x acc =>
-    let res := summator x acc.1
-    (res.1, res.2 :: acc.2)
-    -- match (x, acc.1) with
-    -- (.one, .one)
-  ) (Bit.one, [])).2
-
-def twosComplement := plusOne ∘ onesComplement
 
 def nattob (x : Nat) (endianness : Endian := .big) : ByteArray :=
   match endianness with
@@ -35,12 +10,8 @@ def nattob (x : Nat) (endianness : Endian := .big) : ByteArray :=
 def modPad (modulo : Nat) (bs : List Bit)
            (padWith : Bit := .zero) (endianness : Endian := .big)
            : List Bit := Id.run $ do
-  let l := bs.length
-  let rem := l % modulo
-  let to_replicate := if rem == 0 then
-    0
-  else
-    modulo - rem
+  let rem := bs.length % modulo
+  let to_replicate := if rem == 0 then 0 else modulo - rem
   let pad := List.replicate to_replicate padWith
   match endianness with
   | .big => pad ++ bs
@@ -51,37 +22,24 @@ def ntob (n : Nat) (endianness : Endian := .big) : ByteArray :=
   | .big => n.toByteArrayBE
   | .little => n.toByteArrayLE
 
-def pad7 (xs : List Bit) : List Bit := Id.run $ do
-  modPad 7 xs
+def pad7 (xs : List Bit) : List Bit := modPad 7 xs
 
 /- Remove all the leading zeroes -/
-def unlead (xs : List Bit) : List Bit :=
-  (xs.foldl (fun acc x =>
-    if acc.1 then
-      if x == Bit.zero then
-        (true, acc.2)
-      else
-        (false, acc.2 ++ [x])
-    else
-      (false, acc.2 ++ [x])
-  ) (true, [])).2
+def unlead (xs : List Bit) : List Bit := xs.dropWhile (· = .zero)
 
 def npad7 := pad7 ∘ unlead ∘ ByteArray.toBits ∘ ntob
 
 def sDisambiguatePosInt (xs : List Bit) : ByteArray :=
-  let go := (Nat.toByteArrayLE ∘ Bit.bitsToNat)
-  (match xs with
-  | Bit.zero :: Bit.one :: rest => (go (Bit.one :: Bit.one :: rest)) ++ ByteArray.mk #[0]
-  | _ => go xs)
+  let go := Nat.toByteArrayLE ∘ Bit.bitsToNat
+  match xs with
+  | .zero :: .one :: rest => go (.one :: .one :: rest) ++ ByteArray.mk #[0]
+  | _ => go xs
 
 def spad7 (x : Int) : List Bit :=
-  let go := npad7 ∘ Int.natAbs
-  (if x >= 0 then
-    go
-  else
-    twosComplement ∘ go) x
+  let padded := npad7 x.natAbs
+  if x >= 0 then padded else Bit.twosComplement padded
 
-def reassemble (xs : List Bit) : List Bit := Id.run $ do
+def reassemble (xs : List Bit) : List Bit :=
   (xs.foldl (fun acc x =>
     let leading_bit := if acc.1 then Bit.zero else Bit.one
     let acc2' := if acc.2.1 == 6 then 0 else acc.2.1 + 1
@@ -99,7 +57,7 @@ def uLeb128 : Nat → ByteArray :=
   LebCore ∘ npad7
 
 def sLeb128 (x : Int) : ByteArray :=
-  (if x ≥ 0 then
-    sDisambiguatePosInt ∘ reassemble ∘ spad7
+  if x ≥ 0 then
+    sDisambiguatePosInt ∘ reassemble $ spad7 x
   else
-    LebCore ∘ spad7) x
+    LebCore $ spad7 x

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -122,12 +122,19 @@ mutual
   | le_s  : Type' → Get' → Get' → Operation
   | ge_u  : Type' → Get' → Get' → Operation
   | ge_s  : Type' → Get' → Get' → Operation
+  | lt  : Type' → Get' → Get' → Operation
+  | gt  : Type' → Get' → Get' → Operation
+  | le  : Type' → Get' → Get' → Operation
+  | ge  : Type' → Get' → Get' → Operation
   | clz : Type' → Get' → Operation
   | ctz : Type' → Get' → Operation
   | popcnt : Type' → Get' → Operation
   | add : Type' → Get' → Get' → Operation
   | sub : Type' → Get' → Get' → Operation
   | mul : Type' → Get' → Get' → Operation
+  | div : Type' → Get' → Get' → Operation
+  | max : Type' → Get' → Get' → Operation
+  | min : Type' → Get' → Get' → Operation
   | div_s : Type' → Get' → Get' → Operation
   | div_u : Type' → Get' → Get' → Operation
   | rem_s : Type' → Get' → Get' → Operation
@@ -179,12 +186,19 @@ mutual
       s!"(Operation.ge_u {t} {getToString g1} {getToString g2})"
     | .ge_s t g1 g2 =>
       s!"(Operation.ge_s {t} {getToString g1} {getToString g2})"
+    | .lt  t g1 g2 => s!"(Operation.lt {t} {getToString g1} {getToString g2})"
+    | .gt  t g1 g2 => s!"(Operation.gt {t} {getToString g1} {getToString g2})"
+    | .le  t g1 g2 => s!"(Operation.le {t} {getToString g1} {getToString g2})"
+    | .ge  t g1 g2 => s!"(Operation.ge {t} {getToString g1} {getToString g2})"
     | .clz t g => s!"(Operation.clz {t} {getToString g})"
     | .ctz t g => s!"(Operation.ctz {t} {getToString g})"
     | .popcnt t g => s!"(Operation.popcnt {t} {getToString g})"
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
     | .sub t g1 g2 => s!"(Operation.sub {t} {getToString g1} {getToString g2})"
     | .mul t g1 g2 => s!"(Operation.mul {t} {getToString g1} {getToString g2})"
+    | .div t g1 g2 => s!"(Operation.div {t} {getToString g1} {getToString g2})"
+    | .max t g1 g2 => s!"(Operation.max {t} {getToString g1} {getToString g2})"
+    | .min t g1 g2 => s!"(Operation.min {t} {getToString g1} {getToString g2})"
     | .div_s t g1 g2 =>
       s!"(Operation.div_s {t} {getToString g1} {getToString g2})"
     | .div_u t g1 g2 =>

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -27,9 +27,12 @@ def numUniType : NumUniT → Type'
   | .i x => .i x.bs
   | .f x => .f x.bs
 
+def bitsize : Type' → BitSize
+  | .f bs => bs
+  | .i bs => bs
+
 end Type'
 open Type'
-
 
 namespace Local
 
@@ -108,6 +111,9 @@ mutual
   inductive Operation where
   | nop
   | const : Type' → NumUniT → Operation
+  | clz : Type' → Get' → Operation
+  | ctz : Type' → Get' → Operation
+  | popcnt : Type' → Get' → Operation
   | add : Type' → Get' → Get' → Operation
   | sub : Type' → Get' → Get' → Operation
   | mul : Type' → Get' → Get' → Operation
@@ -143,6 +149,9 @@ mutual
   private partial def operationToString : Operation → String
     | .nop => "(Operation.nop)"
     | .const t n => s!"(Operation.const {t} {n})"
+    | .clz t g => s!"(Operation.clz {t} {getToString g})"
+    | .ctz t g => s!"(Operation.ctz {t} {getToString g})"
+    | .popcnt t g => s!"(Operation.popcnt {t} {getToString g})"
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
     | .sub t g1 g2 => s!"(Operation.sub {t} {getToString g1} {getToString g2})"
     | .mul t g1 g2 => s!"(Operation.mul {t} {getToString g1} {getToString g2})"

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -111,6 +111,17 @@ mutual
   inductive Operation where
   | nop
   | const : Type' → NumUniT → Operation
+  | eqz : Type' → Get' → Operation
+  | eq  : Type' → Get' → Get' → Operation
+  | ne  : Type' → Get' → Get' → Operation
+  | lt_u  : Type' → Get' → Get' → Operation
+  | lt_s  : Type' → Get' → Get' → Operation
+  | gt_u  : Type' → Get' → Get' → Operation
+  | gt_s  : Type' → Get' → Get' → Operation
+  | le_u  : Type' → Get' → Get' → Operation
+  | le_s  : Type' → Get' → Get' → Operation
+  | ge_u  : Type' → Get' → Get' → Operation
+  | ge_s  : Type' → Get' → Get' → Operation
   | clz : Type' → Get' → Operation
   | ctz : Type' → Get' → Operation
   | popcnt : Type' → Get' → Operation
@@ -149,6 +160,25 @@ mutual
   private partial def operationToString : Operation → String
     | .nop => "(Operation.nop)"
     | .const t n => s!"(Operation.const {t} {n})"
+    | .eqz t g => s!"(Operation.eqz {t} {getToString g})"
+    | .eq  t g1 g2 => s!"(Operation.eq {t} {getToString g1} {getToString g2})"
+    | .ne  t g1 g2 => s!"(Operation.ne {t} {getToString g1} {getToString g2})"
+    | .lt_u t g1 g2 =>
+      s!"(Operation.lt_u {t} {getToString g1} {getToString g2})"
+    | .lt_s t g1 g2 =>
+      s!"(Operation.lt_s {t} {getToString g1} {getToString g2})"
+    | .gt_u t g1 g2 =>
+      s!"(Operation.gt_u {t} {getToString g1} {getToString g2})"
+    | .gt_s t g1 g2 =>
+      s!"(Operation.gt_s {t} {getToString g1} {getToString g2})"
+    | .le_u t g1 g2 =>
+      s!"(Operation.le_u {t} {getToString g1} {getToString g2})"
+    | .le_s t g1 g2 =>
+      s!"(Operation.le_s {t} {getToString g1} {getToString g2})"
+    | .ge_u t g1 g2 =>
+      s!"(Operation.ge_u {t} {getToString g1} {getToString g2})"
+    | .ge_s t g1 g2 =>
+      s!"(Operation.ge_s {t} {getToString g1} {getToString g2})"
     | .clz t g => s!"(Operation.clz {t} {getToString g})"
     | .ctz t g => s!"(Operation.ctz {t} {getToString g})"
     | .popcnt t g => s!"(Operation.popcnt {t} {getToString g})"

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -109,6 +109,20 @@ mutual
   | nop
   | const : Type' → NumUniT → Operation
   | add : Type' → Get' → Get' → Operation
+  | sub : Type' → Get' → Get' → Operation
+  | mul : Type' → Get' → Get' → Operation
+  | div_s : Type' → Get' → Get' → Operation
+  | div_u : Type' → Get' → Get' → Operation
+  | rem_s : Type' → Get' → Get' → Operation
+  | rem_u : Type' → Get' → Get' → Operation
+  | and : Type' → Get' → Get' → Operation
+  | or : Type' → Get' → Get' → Operation
+  | xor : Type' → Get' → Get' → Operation
+  | shl : Type' → Get' → Get' → Operation
+  | shr_u : Type' → Get' → Get' → Operation
+  | shr_s : Type' → Get' → Get' → Operation
+  | rotl : Type' → Get' → Get' → Operation
+  | rotr : Type' → Get' → Get' → Operation
   | block : List Type' → List Operation → Operation
   | loop : List Type' → List Operation → Operation
   | if : List Type' → List Operation → List Operation → Operation
@@ -130,6 +144,28 @@ mutual
     | .nop => "(Operation.nop)"
     | .const t n => s!"(Operation.const {t} {n})"
     | .add t g1 g2 => s!"(Operation.add {t} {getToString g1} {getToString g2})"
+    | .sub t g1 g2 => s!"(Operation.sub {t} {getToString g1} {getToString g2})"
+    | .mul t g1 g2 => s!"(Operation.mul {t} {getToString g1} {getToString g2})"
+    | .div_s t g1 g2 =>
+      s!"(Operation.div_s {t} {getToString g1} {getToString g2})"
+    | .div_u t g1 g2 =>
+      s!"(Operation.div_u {t} {getToString g1} {getToString g2})"
+    | .rem_s t g1 g2 =>
+      s!"(Operation.rem_s {t} {getToString g1} {getToString g2})"
+    | .rem_u t g1 g2 =>
+      s!"(Operation.rem_u {t} {getToString g1} {getToString g2})"
+    | .and t g1 g2 => s!"(Operation.and {t} {getToString g1} {getToString g2})"
+    | .or t g1 g2 => s!"(Operation.or {t} {getToString g1} {getToString g2})"
+    | .xor t g1 g2 => s!"(Operation.xor {t} {getToString g1} {getToString g2})"
+    | .shl t g1 g2 => s!"(Operation.shl {t} {getToString g1} {getToString g2})"
+    | .shr_u t g1 g2 =>
+      s!"(Operation.shr_u {t} {getToString g1} {getToString g2})"
+    | .shr_s t g1 g2 =>
+      s!"(Operation.shr_s {t} {getToString g1} {getToString g2})"
+    | .rotl t g1 g2 =>
+      s!"(Operation.rotl {t} {getToString g1} {getToString g2})"
+    | .rotr t g1 g2 =>
+      s!"(Operation.rotr {t} {getToString g1} {getToString g2})"
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
     | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
     | .if ts thens elses => s!"(Operation.if {ts} {thens.map operationToString} {elses.map operationToString})"

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -29,6 +29,11 @@ def unsign (i : Int) (size : BitSize := 64) : Int :=
   | .ofNat m => m
   | .negSucc _ => i + ((2 : Int) ^ (size : Nat))
 
+def toNBits (i : Int) (size : BitSize := 64) : List Bit :=
+  let bits := i.toBits
+  let padbit := if i ≥ 0 then .zero else .one
+  List.replicate (size - bits.length) padbit ++ bits
+
 namespace Wasm.Wast.Num
 
 namespace NumType

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -8,6 +8,7 @@ import Megaparsec.Errors
 import Megaparsec.Errors.Bundle
 import Megaparsec.Parsec
 import Megaparsec.MonadParsec
+import YatimaStdLib.Cached
 import YatimaStdLib.NonEmpty
 
 open Wasm.Wast.Parser.Common

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -21,6 +21,14 @@ open Megaparsec.Parsec
 open MonadParsec
 open Cached
 
+-- Turns a negative integer into a positive by taking its
+-- bit representation and interpreting it as unsigned.
+-- `size` is the number of bits to assume
+def unsign (i : Int) (size : BitSize := 64) : Int :=
+  match i with
+  | .ofNat m => m
+  | .negSucc _ => i + ((2 : Int) ^ (size : Nat))
+
 namespace Wasm.Wast.Num
 
 namespace NumType

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -91,13 +91,20 @@ private def brifP : Parsec Char String Unit Operation := do
 
  mutual
 
-  partial def get'ViaGetP (α  : Type') : Parsec Char String Unit Get' :=
+  partial def get'ViaGetP (α : Type') : Parsec Char String Unit Get' :=
     attempt (opP >>= (pure ∘ Get'.from_operation)) <|>
     (getP >>= (pure ∘ stripGet α))
 
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
-      nopP <|> constP <|> addP <|>
+      nopP <|> constP <|>
+        binopP "add" .add <|> binopP "sub" .sub <|> binopP "mul" .mul <|>
+        iBinopP "div_s" .div_s <|> iBinopP "div_u" .div_u <|>
+        iBinopP "rem_s" .rem_s <|> iBinopP "rem_u" .rem_u <|>
+        iBinopP "and" .and <|> iBinopP "or" .or <|> iBinopP "xor" .xor <|>
+        iBinopP "shl" .shl <|>
+        iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
+        iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
         blockP <|> loopP <|> ifP <|>
         brP <|> brifP
 
@@ -128,20 +135,38 @@ private def brifP : Parsec Char String Unit Operation := do
     owP <* option' (string "end")
     pure $ .if ts thens elses
 
-  partial def addP : Parsec Char String Unit Operation := do
+  partial def iBinopP (opS : String) (binopMk : Type' → Get' → Get' → Operation)
+              : Parsec Char String Unit Operation := do
     -- TODO: we'll use ps when we'll add more types into `Type'`.
     -- let _ps ← getParserState
-    let add_t : Type' ←
-      string "i32.add" *> (pure $ .i 32) <|>
-      string "i64.add" *> (pure $ .i 64) <|>
-      string "f32.add" *> (pure $ .f 32) <|>
-      string "f64.add" *> (pure $ .f 64)
+    let type : Type' ←
+      string s!"i32.{opS}" *> (pure $ .i 32) <|>
+      string s!"i64.{opS}" *> (pure $ .i 64)
     ignoreP
-    let (arg_1 : Get') ← get'ViaGetP add_t
+    let (arg_1 : Get') ← get'ViaGetP type
     owP
-    let (arg_2 : Get') ← get'ViaGetP add_t
+    let (arg_2 : Get') ← get'ViaGetP type
     owP
-    pure $ Operation.add add_t arg_1 arg_2
+    pure $ binopMk type arg_1 arg_2
+
+  partial def fBinopP (opS : String) (binopMk : Type' → Get' → Get' → Operation)
+              : Parsec Char String Unit Operation := do
+    -- TODO: we'll use ps when we'll add more types into `Type'`.
+    -- let _ps ← getParserState
+    let type : Type' ←
+      string s!"f32.{opS}" *> (pure $ .f 32) <|>
+      string s!"f64.{opS}" *> (pure $ .f 64)
+    ignoreP
+    let (arg_1 : Get') ← get'ViaGetP type
+    owP
+    let (arg_2 : Get') ← get'ViaGetP type
+    owP
+    pure $ binopMk type arg_1 arg_2
+
+  partial def binopP (opS : String) (binopMk : Type' → Get' → Get' → Operation)
+              : Parsec Char String Unit Operation :=
+    iBinopP opS binopMk <|> fBinopP opS binopMk
+
 end
 
 

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -98,6 +98,12 @@ private def brifP : Parsec Char String Unit Operation := do
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
       nopP <|> constP <|>
+      iUnopP "eqz" .eqz <|>
+      binopP "eq" .eq <|> binopP "ne" .ne <|>
+      iBinopP "lt_u" .lt_u <|> iBinopP "lt_s" .lt_s <|>
+      iBinopP "gt_u" .gt_u <|> iBinopP "gt_s" .gt_s <|>
+      iBinopP "le_u" .le_u <|> iBinopP "le_s" .le_s <|>
+      iBinopP "ge_u" .ge_u <|> iBinopP "ge_s" .ge_s <|>
       iUnopP "clz" .clz <|> iUnopP "ctz" .ctz <|> iUnopP "popcnt" .popcnt <|>
       binopP "add" .add <|> binopP "sub" .sub <|> binopP "mul" .mul <|>
       iBinopP "div_s" .div_s <|> iBinopP "div_u" .div_u <|>

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -98,15 +98,16 @@ private def brifP : Parsec Char String Unit Operation := do
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
       nopP <|> constP <|>
-        binopP "add" .add <|> binopP "sub" .sub <|> binopP "mul" .mul <|>
-        iBinopP "div_s" .div_s <|> iBinopP "div_u" .div_u <|>
-        iBinopP "rem_s" .rem_s <|> iBinopP "rem_u" .rem_u <|>
-        iBinopP "and" .and <|> iBinopP "or" .or <|> iBinopP "xor" .xor <|>
-        iBinopP "shl" .shl <|>
-        iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
-        iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
-        blockP <|> loopP <|> ifP <|>
-        brP <|> brifP
+      iUnopP "clz" .clz <|> iUnopP "ctz" .ctz <|> iUnopP "popcnt" .popcnt <|>
+      binopP "add" .add <|> binopP "sub" .sub <|> binopP "mul" .mul <|>
+      iBinopP "div_s" .div_s <|> iBinopP "div_u" .div_u <|>
+      iBinopP "rem_s" .rem_s <|> iBinopP "rem_u" .rem_u <|>
+      iBinopP "and" .and <|> iBinopP "or" .or <|> iBinopP "xor" .xor <|>
+      iBinopP "shl" .shl <|>
+      iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
+      iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
+      blockP <|> loopP <|> ifP <|>
+      brP <|> brifP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP
@@ -134,6 +135,16 @@ private def brifP : Parsec Char String Unit Operation := do
     let elses ← opsP
     owP <* option' (string "end")
     pure $ .if ts thens elses
+
+  partial def iUnopP (opS : String) (unopMk : Type' → Get' → Operation)
+              : Parsec Char String Unit Operation := do
+    let type : Type' ←
+      string s!"i32.{opS}" *> (pure $ .i 32) <|>
+      string s!"i64.{opS}" *> (pure $ .i 64)
+    ignoreP
+    let arg ← get'ViaGetP type
+    owP
+    pure $ unopMk type arg
 
   partial def iBinopP (opS : String) (binopMk : Type' → Get' → Get' → Operation)
               : Parsec Char String Unit Operation := do

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,0 +1,33 @@
+{"version": 4,
+ "packagesDir": "./lake-packages",
+ "packages":
+ [{"git":
+   {"url": "https://github.com/yatima-inc/Megaparsec.lean",
+    "subDir?": null,
+    "rev": "0572258b1cfee6a399d0b867a764cee97e73a254",
+    "name": "Megaparsec",
+    "inputRev?": "0572258b1cfee6a399d0b867a764cee97e73a254"}},
+  {"git":
+   {"url": "https://github.com/yatima-inc/YatimaStdLib.lean",
+    "subDir?": null,
+    "rev": "533d71efa5853ff014f42c174d6321d74251209f",
+    "name": "YatimaStdLib",
+    "inputRev?": "533d71efa5853ff014f42c174d6321d74251209f"}},
+  {"git":
+   {"url": "https://github.com/yatima-inc/straume",
+    "subDir?": null,
+    "rev": "9597873f0b18a9e97b7315fb84968c55d09a6112",
+    "name": "Straume",
+    "inputRev?": "9597873f0b18a9e97b7315fb84968c55d09a6112"}},
+  {"git":
+   {"url": "https://github.com/yatima-inc/LSpec",
+    "subDir?": null,
+    "rev": "88f7d23e56a061d32c7173cea5befa4b2c248b41",
+    "name": "LSpec",
+    "inputRev?": "88f7d23e56a061d32c7173cea5befa4b2c248b41"}},
+  {"git":
+   {"url": "https://github.com/leanprover/std4/",
+    "subDir?": null,
+    "rev": "fde95b16907bf38ea3f310af406868fc6bcf48d1",
+    "name": "std",
+    "inputRev?": "fde95b16907bf38ea3f310af406868fc6bcf48d1"}}]}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,16 +9,16 @@ package Wasm {
 lean_lib Wasm
 
 require LSpec from git
-  "https://github.com/yatima-inc/LSpec" @ "89798a6cb76b2b29469ff752af2fd8543b3a5515"
+  "https://github.com/yatima-inc/LSpec" @ "88f7d23e56a061d32c7173cea5befa4b2c248b41"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "f905b68f529de2af44cf6ea63489b7e3cd090050"
+  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "533d71efa5853ff014f42c174d6321d74251209f"
 
 require Megaparsec from git
-  "https://github.com/yatima-inc/Megaparsec.lean" @ "50f9beb2af165f5736155d30cdda2774784b677b"
+  "https://github.com/yatima-inc/Megaparsec.lean" @ "0572258b1cfee6a399d0b867a764cee97e73a254"
 
-require Yatima from git
-  "https://github.com/yatima-inc/yatima-lang" @ "26e896debf14cf3bb09a7a8a00f70583ae95469d"
+-- require Yatima from git
+--   "https://github.com/yatima-inc/yatima-lang" @ "26e896debf14cf3bb09a7a8a00f70583ae95469d"
 
 @[default_target]
 lean_exe wasm {

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-11-14
+leanprover/lean4:nightly-2023-01-10


### PR DESCRIPTION
Problem: we support very few numerical operations. We need moar.

Solution:
- Supported all integer binary operations.
  Namely `add`, `sub`, `mul`, `div_s`, `div_u`, `rem_s`, `rem_u`, `and`, `or`, `xor`, `shl`, `shr_s`, `shr_u`, `rotl`, `rotr`
- Supported all integer unary operations.
  Namely `clz`, `ctz`, `popcnt`
- Supported all integer relational operations.
  Namely `eqz`, `eq`, `ne`, `lt_u`, `lt_s`, `gt_u`, `gt_s`, `le_u`, `le_s`, `ge_u`, `ge_s`

Also added some support for some float numerical instructions, but for now it's a lost cause as Lean's implementation of `Float`s is utterly unsuitable for Wasm.