### PR TITLE
Support variable instructions for locals

### DIFF
--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -10,7 +10,6 @@ open Wasm.Wast.AST.Type'
 open Wasm.Wast.AST.Local
 open Wasm.Wast.AST.Operation
 open Wasm.Wast.AST.Func
-open Wasm.Wast.AST.Get
 
 open ByteArray
 open Nat

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -301,8 +301,6 @@ mutual
     match x with
     | .from_stack => b0
     | .from_operation o => extractOp o
-    -- TODO: handle locals
-    | _ => sorry
 
   partial def extractOp (x : Operation) : ByteArray :=
     match x with

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -308,6 +308,7 @@ mutual
   partial def extractOp (x : Operation) : ByteArray :=
     match x with
     | .nop => b 0x01
+    | .drop => b 0x1a
     -- TODO: signed consts exist??? We should check the spec carefully.
     | .const (.i 32) (.i ci) => b 0x41 ++ sLeb128 ci.val
     | .const (.i 64) (.i ci) => b 0x42 ++ sLeb128 ci.val

--- a/Wasm/Engine.lean
+++ b/Wasm/Engine.lean
@@ -290,6 +290,7 @@ mutual
 
     match op with
     | .nop => pure ⟨⟩
+    | .drop => discard bite
     | .const _t n => push $ .num n
     | .eqz _t g => runIUnop g $ (if · = 0 then 1 else 0)
     | .eq (.i _) g0 g1 => runIBinop g0 g1 (if · = · then 1 else 0)

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -15,7 +15,7 @@ inductive Type' where
   | f : BitSize → Type'
   | i : BitSize → Type'
   -- | v : BitSizeSIMD → Type'
-  deriving BEq
+  deriving DecidableEq
 
 instance : ToString Type' where
   toString x := match x with
@@ -40,7 +40,7 @@ structure Local where
   index : Nat
   name : Option String
   type : Type' -- TODO: We need to pack lists with different related types'. For that we need something cooler than List, but since we're just coding now, we'll do it later.
-  deriving BEq
+  deriving DecidableEq
 
 instance : ToString Local where
   toString x := s!"(Local.mk {x.index} {x.type})"
@@ -80,8 +80,6 @@ mutual
   inductive Get' where
   | from_stack
   | from_operation : Operation → Get'
-  | by_name : Local → Get'
-  | by_index : Local → Get'
 
 -- TODO: add support for function type indexes for blocktypes
 -- TODO: branching ops can produce and consume operands themselves,
@@ -137,14 +135,9 @@ mutual
 end
 
 mutual
-  private partial def getToString (x : Get') : String :=
-    "(Get'" ++ (
-      match x with
-      | .from_stack => ".from_stack"
-      | .from_operation o => s!".from_operation {operationToString o}"
-      | .by_name n => ".by_name " ++ toString n
-      | .by_index i => ".by_index " ++ toString i
-    ) ++ ")"
+  private partial def getToString : Get' → String
+    | .from_stack => "(Get'.from_stack)"
+    | .from_operation o => s!"(Get'.from_operation {operationToString o})"
 
   private partial def operationToString : Operation → String
     | .nop => "(Operation.nop)"

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -67,25 +67,6 @@ end LabelIndex
 open LabelIndex
 
 
-namespace Get
-
-inductive Get (x : Type') where
-| from_stack
-| by_name : Local → Get x
-| by_index : Local → Get x
-
-instance : ToString (Get α) where
-  toString x := "(" ++ (
-    match x with
-    | .from_stack => "Get.from_stack"
-    | .by_name n => "Get.by_name " ++ toString n
-    | .by_index i => "Get.by_index " ++ toString i
-  ) ++ " : Get " ++ toString α ++ ")"
-
-end Get
-open Get
-
-
 /- TODO: Instructions are rigid WAT objects. If we choose to only support
 S-Expressions at this point, we don't need this concept. -/
 namespace Instruction

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -110,6 +110,7 @@ mutual
 -- can't be populated with `ConstFloat`!
   inductive Operation where
   | nop
+  | drop
   | const : Type' → NumUniT → Operation
   | eqz : Type' → Get' → Operation
   | eq  : Type' → Get' → Get' → Operation
@@ -166,6 +167,7 @@ mutual
 
   private partial def operationToString : Operation → String
     | .nop => "(Operation.nop)"
+    | .drop => "(Operation.drop)"
     | .const t n => s!"(Operation.const {t} {n})"
     | .eqz t g => s!"(Operation.eqz {t} {getToString g})"
     | .eq  t g1 g2 => s!"(Operation.eq {t} {getToString g1} {getToString g2})"

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -45,6 +45,15 @@ structure Local where
 instance : ToString Local where
   toString x := s!"(Local.mk {x.index} {x.type})"
 
+inductive LocalLabel where
+  | by_index : Nat → LocalLabel
+  | by_name : String → LocalLabel
+  deriving Repr, DecidableEq
+
+instance : ToString LocalLabel where
+  toString | .by_index n => s!"(LocalLabel.by_index {n})"
+           | .by_name  n => s!"(LocalLabel.by_name \"{n}\")"
+
 end Local
 open Local
 
@@ -127,6 +136,9 @@ mutual
   | shr_s : Type' → Get' → Get' → Operation
   | rotl : Type' → Get' → Get' → Operation
   | rotr : Type' → Get' → Get' → Operation
+  | local_get : LocalLabel → Operation
+  | local_set : LocalLabel → Operation
+  | local_tee : LocalLabel → Operation
   | block : List Type' → List Operation → Operation
   | loop : List Type' → List Operation → Operation
   | if : List Type' → List Operation → List Operation → Operation
@@ -195,6 +207,9 @@ mutual
       s!"(Operation.rotl {t} {getToString g1} {getToString g2})"
     | .rotr t g1 g2 =>
       s!"(Operation.rotr {t} {getToString g1} {getToString g2})"
+    | .local_get l => s!"(Operation.local_get {l})"
+    | .local_set l => s!"(Operation.local_set {l})"
+    | .local_tee l => s!"(Operation.local_tee {l})"
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
     | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
     | .if ts thens elses => s!"(Operation.if {ts} {thens.map operationToString} {elses.map operationToString})"

--- a/Wasm/Wast/BitSize.lean
+++ b/Wasm/Wast/BitSize.lean
@@ -14,13 +14,13 @@ We define BitSize inductive to then combine it with respective constructors. -/
 inductive BitSize :=
 | thirtyTwo
 | sixtyFour
-deriving BEq
+deriving DecidableEq
 
 /- Webassembly supports SIMD instructions over blobs of 128 bits.
 In case they'll support other sizes of blobs, we recorded this fact into an inductive. -/
 inductive BitSizeSIMD :=
 | hundredTwentyEight
-deriving BEq
+deriving DecidableEq
 
 -- Boring instances
 

--- a/Wasm/Wast/Code.lean
+++ b/Wasm/Wast/Code.lean
@@ -34,3 +34,5 @@ def reindexParamsAndLocals (f : Func) : (List Local × List Local) :=
   let ls := reindexLocals (ps.length) f.locals
   (ps, ls)
 
+def replaceNth (xs : List α) (idx : Nat) (x : α) :=
+  xs.take idx ++ x :: xs.drop (idx+1)

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -405,6 +405,7 @@ open Num.Float
 inductive NumUniT where
 | i : ConstInt → NumUniT
 | f : ConstFloat → NumUniT
+  deriving BEq
 
 instance : ToString NumUniT where
   toString | .i ci => toString ci

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -33,7 +33,6 @@ section textparser
 
 open Type'
 open Local
-open Get
 open Operation
 open Func
 open Module
@@ -59,17 +58,6 @@ def brResultP : Parsec Char String Unit (List Type') :=
 def brResultsP : Parsec Char String Unit (List Type') :=
   List.join <$> manyLispP resultP
 
-
-def getP : Parsec Char String Unit (Get x) :=
-  -- TODO: implement locals!!!
-  pure $ Get.from_stack
-
-def stripGet (α : Type') (x : Get α) : Get' :=
-  match x with
-  | .from_stack => Get'.from_stack
-  | .by_name n => Get'.by_name n
-  | .by_index i => Get'.by_index i
-
 private def nopP : Parsec Char String Unit Operation :=
   string "nop" *> pure .nop
 
@@ -94,9 +82,9 @@ private def brifP : Parsec Char String Unit Operation := do
 
  mutual
 
-  partial def get'ViaGetP (α : Type') : Parsec Char String Unit Get' :=
-    attempt (opP >>= (pure ∘ Get'.from_operation)) <|>
-    (getP >>= (pure ∘ stripGet α))
+  partial def getP : Parsec Char String Unit Get' :=
+    attempt (pure ∘ .from_operation =<< opP) <|>
+    pure .from_stack
 
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
@@ -154,7 +142,7 @@ private def brifP : Parsec Char String Unit Operation := do
       string s!"i32.{opS}" *> (pure $ .i 32) <|>
       string s!"i64.{opS}" *> (pure $ .i 64)
     ignoreP
-    let arg ← get'ViaGetP type
+    let arg ← getP
     owP
     pure $ unopMk type arg
 
@@ -167,9 +155,9 @@ private def brifP : Parsec Char String Unit Operation := do
       string s!"{tChar}32.{opS}" *> (pure $ con 32) <|>
       string s!"{tChar}64.{opS}" *> (pure $ con 64)
     ignoreP
-    let arg_1 ← get'ViaGetP type
+    let arg_1 ← getP
     owP
-    let arg_2 ← get'ViaGetP type
+    let arg_2 ← getP
     owP
     pure $ binopMk type arg_1 arg_2
 

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -73,6 +73,9 @@ def stripGet (α : Type') (x : Get α) : Get' :=
 private def nopP : Parsec Char String Unit Operation :=
   string "nop" *> pure .nop
 
+private def dropP : Parsec Char String Unit Operation :=
+  string "drop" *> pure .drop
+
 private def constP : Parsec Char String Unit Operation := do
   -- TODO: we'll use ps when we'll add more types into `Type'`.
   -- let _ps ← getParserState
@@ -97,7 +100,7 @@ private def brifP : Parsec Char String Unit Operation := do
 
   partial def opP : Parsec Char String Unit Operation :=
     Char.between '(' ')' $ owP *>
-      nopP <|> constP <|>
+      nopP <|> dropP <|> constP <|>
       iUnopP "eqz" .eqz <|>
       binopP "eq" .eq <|> binopP "ne" .ne <|>
       iBinopP "lt_u" .lt_u <|> iBinopP "lt_s" .lt_s <|>


### PR DESCRIPTION
Problem: we currently have extremely preliminary support for params and locals, but we don't support variable instructions at all.

Solution: introduced another `StateT` layer to our `EngineM` stack to house local values.
Supported instructions that manipulate locals, namely `local.get`, `local.set`, `local.tee`
NB: binary encoding is only supported for local instructions that refer to locals by indices, not by names

Also supported `drop`.