### PR TITLE
Support global instructions

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -383,6 +383,9 @@ def main : IO Unit := do
 
   -- TODO: pack more ascii into the easter egg with i64
   let i := "(module
+    (global $a i32 (i32.const 1499550000))
+    (global i32 (i32.const 17))
+
     (func $main (export \"main\")
       (param $x i32)
       (param i32)
@@ -390,8 +393,8 @@ def main : IO Unit := do
 
       (block (result i32) (i32.const 3) (i32.add (br 0) (i32.const 9)))
       (i32.add
-        (i32.const 1499550000)
-        (i32.add (i32.const 9000) (i32.const 17))
+        (global.get $a)
+        (i32.add (i32.const 9000) (global.get 1))
       )
 
     )
@@ -423,7 +426,7 @@ def main : IO Unit := do
     | .some fid =>
       let eres := run store fid $ Stack.mk [se_zero, se_zero]
       match eres with
-      | .ok stack2 => match stack2.es with
+      | .ok (_, stack2) => match stack2.es with
         | [] => "UNEXPECTED RESULT"
         | xs => s!"!!!!!!!!!!!!!! SUCCESS !!!!!!!!!!!!!!!!\n{xs}"
       | .error ee => s!"FAILED TO RUN `main` CORRECTLY: {ee}"

--- a/Wasm/Engine.lean
+++ b/Wasm/Engine.lean
@@ -143,12 +143,11 @@ structure FunctionInstance (x : Module) where
 /- TODO: Unify this with Bytes.indexFuncs -/
 def instantiateFs (m : Module) : List (FunctionInstance m) :=
   let go acc f :=
-    let pl := reindexParamsAndLocals f
     let fi := FunctionInstance.mk f.name
                                   f.export_
-                                  pl.1
+                                  f.params
                                   f.results
-                                  pl.2
+                                  f.locals
                                   0
                                   f.ops
     match acc with
@@ -479,8 +478,8 @@ def runDo (s : Store m)
       else .error .param_type_incompatible
     | _ :: _ => .error .param_type_incompatible
   let pσ ← f.params.foldl bite $ .ok (σ.es, [])
-  let locals := (f.params ++ f.locals).map
-    fun l => ⟨l.name, pσ.2.get? l.index, l.type⟩
+  let locals := (f.params ++ f.locals).enum.map
+    fun l => ⟨l.2.name, pσ.2.get? l.1, l.2.type⟩
   let ses ← (f.ops.forM runOp).run pσ.1 locals s.globals
   pure (ses.2, Stack.mk ses.1.1.2)
 

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -57,6 +57,20 @@ instance : ToString LocalLabel where
 end Local
 open Local
 
+namespace Global
+
+inductive GlobalLabel where
+  | by_index : Nat → GlobalLabel
+  | by_name : String → GlobalLabel
+  deriving Repr, DecidableEq
+
+instance : ToString GlobalLabel where
+  toString | .by_index n => s!"(GlobalLabel.by_index {n})"
+           | .by_name  n => s!"(GlobalLabel.by_name \"{n}\")"
+
+end Global
+open Global
+
 namespace LabelIndex
 
 structure LabelIndex where
@@ -228,6 +242,30 @@ end Operation
 open Operation
 
 
+namespace Global
+
+structure GlobalType where
+  var : Bool
+  type : Type'
+  deriving DecidableEq
+
+instance : ToString GlobalType where
+  toString
+    | ⟨false, t⟩ => s!"(GlobalType const {t})"
+    | ⟨true,  t⟩ => s!"(GlobalType var {t})"
+
+structure Global where
+  index : Nat
+  name : Option String
+  type : GlobalType
+  init : Operation
+
+instance : ToString Global where
+  toString x := s!"(Global {x.index} {x.type} {x.init})"
+
+end Global
+open Global
+
 namespace Func
 
 structure Func where
@@ -250,6 +288,7 @@ namespace Module
 
 structure Module where
   name : Option String
+  globals : List Global
   func : List Func
 
 instance : ToString Module where

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -37,13 +37,14 @@ open Type'
 namespace Local
 
 structure Local where
-  index : Nat
   name : Option String
   type : Type' -- TODO: We need to pack lists with different related types'. For that we need something cooler than List, but since we're just coding now, we'll do it later.
   deriving DecidableEq
 
 instance : ToString Local where
-  toString x := s!"(Local.mk {x.index} {x.type})"
+  toString
+    | ⟨.some name, t⟩ => s!"(Local.mk \"{name}\" {t})"
+    | ⟨.none,      t⟩ => s!"(Local.mk {t})"
 
 inductive LocalLabel where
   | by_index : Nat → LocalLabel
@@ -259,13 +260,14 @@ instance : ToString GlobalType where
     | ⟨true,  t⟩ => s!"(GlobalType var {t})"
 
 structure Global where
-  index : Nat
   name : Option String
   type : GlobalType
   init : Operation
 
 instance : ToString Global where
-  toString x := s!"(Global {x.index} {x.type} {x.init})"
+  toString
+    | ⟨.some name, type, init⟩ => s!"(Global \"{name}\" {type} {init})"
+    | ⟨.none,      type, init⟩ => s!"(Global {type} {init})"
 
 end Global
 open Global

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -153,6 +153,8 @@ mutual
   | local_get : LocalLabel → Operation
   | local_set : LocalLabel → Operation
   | local_tee : LocalLabel → Operation
+  | global_get : GlobalLabel → Operation
+  | global_set : GlobalLabel → Operation
   | block : List Type' → List Operation → Operation
   | loop : List Type' → List Operation → Operation
   | if : List Type' → List Operation → List Operation → Operation
@@ -224,6 +226,8 @@ mutual
     | .local_get l => s!"(Operation.local_get {l})"
     | .local_set l => s!"(Operation.local_set {l})"
     | .local_tee l => s!"(Operation.local_tee {l})"
+    | .global_get l => s!"(Operation.global_get {l})"
+    | .global_set l => s!"(Operation.global_set {l})"
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
     | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
     | .if ts thens elses => s!"(Operation.if {ts} {thens.map operationToString} {elses.map operationToString})"
@@ -245,7 +249,7 @@ open Operation
 namespace Global
 
 structure GlobalType where
-  var : Bool
+  mut? : Bool
   type : Type'
   deriving DecidableEq
 

--- a/Wasm/Wast/Code.lean
+++ b/Wasm/Wast/Code.lean
@@ -27,12 +27,5 @@ open Wasm.Wast.Num.Num.Float
 
 namespace Wasm.Wast.Code
 
-open Local in
-open Func in
-def reindexParamsAndLocals (f : Func) : (List Local × List Local) :=
-  let ps := reindexLocals 0 f.params
-  let ls := reindexLocals (ps.length) f.locals
-  (ps, ls)
-
 def replaceNth (xs : List α) (idx : Nat) (x : α) :=
   xs.take idx ++ x :: xs.drop (idx+1)

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -83,8 +83,12 @@ private def localOpP : Parsec Char String Unit Operation := do
   let op ← (string "local.get" *> pure Operation.local_get)
        <|> (string "local.set" *> pure .local_set)
        <|> (string "local.tee" *> pure .local_tee)
-  ignoreP
-  pure $ op (←localLabelP)
+  ignoreP *> op <$> localLabelP
+
+private def globalOpP : Parsec Char String Unit Operation := do
+  let op ← (string "global.get" *> pure Operation.global_get)
+       <|> (string "global.set" *> pure .global_set)
+  ignoreP *> op <$> globalLabelP
 
 private def brP : Parsec Char String Unit Operation := do
   string "br" *> ignoreP
@@ -122,7 +126,7 @@ private def brifP : Parsec Char String Unit Operation := do
       iBinopP "shl" .shl <|>
       iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
       iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
-      localOpP <|> blockP <|> loopP <|> ifP <|>
+      localOpP <|> globalOpP <|> blockP <|> loopP <|> ifP <|>
       brP <|> brifP
       <* owP
 


### PR DESCRIPTION
Problem: we still don't have globals' support in Wasm.lean.

Solution: started by adding the relevant structures, extending the Module structure, and adding various globals parse functions. Added parsing, binary encoding, and Engine support for `global.{get,set}`.

Also: made Bytes.lean better by hiding all the unseemly global and local lists under a small `ReaderT` stack and removed indices from `Global` and `Local` structure definitions. See reasoning in commit messages.