### PR TITLE
[#42] Add basic CI pipeline

### DIFF
--- a/.github/workflows/lspec.yml
+++ b/.github/workflows/lspec.yml
@@ -1,0 +1,40 @@
+name: "LSpec CI"
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: lake build
+    runs-on: ubuntu-latest
+    steps:
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v2
+      - name: build Wasm
+        run: lake build
+
+  tests:
+    name: LSpec tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: install elan
+        run: |
+          set -o pipefail
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          ./elan-init -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> $GITHUB_PATH
+      - uses: actions/checkout@v2
+      - name: build LSpec binary
+        run: lake build lspec
+      - name: fetch wasm-sandbox
+        run: |
+          wget https://github.com/cognivore/wasm-sandbox/releases/download/v1/wasm-sandbox
+          chmod +x ./wasm-sandbox
+      - name: run LSpec
+        run: lake exe lspec


### PR DESCRIPTION
Problem: tests are merged, but we don't enforce they ever pass.

Solution: added a standard GA CI config that builds wasm and runs LSpec.

Closes #42