### PR TITLE
Add tests to our whole implementation

### DIFF
--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -209,12 +209,39 @@ def modsLocal :=
   ))"
   ]
 
+def modsGlobal :=
+  [
+    "(module
+       (global $a i32 (i32.const -2)) (global i32 (i32.const -3))
+       (global $b i64 (i64.const -5))
+       (func (result i64) (global.get $b))
+       (func (export \"as-if-else\") (result i32)
+         (if (result i32) (i32.const 0)
+           (then (i32.const 2)) (else (global.get 1))
+         )
+       )
+     )"
+  , "(module (global $a i32 (i32.const -2)))"
+  , "(module
+       (global i32 (i32.const 17)) (global $a i32 (i32.const -2))
+       (func (param i32) (result i32)
+         (local.get 0) (i32.const 5) (global.set 0) (global.set $a)
+       )
+     )"
+  , "(module (global i64 (i64.const 99999999999)))"
+  , "(module (global $x i32 (i32.const 0))
+       (func (export \"as-binary-operand\") (result i32)
+         (i32.mul (global.get $x) (global.get $x))
+       )
+     )"
+  ]
+
 open IO.Process (run) in
 def doesWasmSandboxRun? :=
   run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
 
 def withWasmSandboxRun : IO UInt32 :=
-  let testCases := [ uWasmMods, modsControl, modsLocal ]
+  let testCases := [ uWasmMods, modsControl, modsLocal, modsGlobal ]
   lspecEachIO testCases.join moduleTestSeq
 
 def withWasmSandboxFail : IO UInt32 :=

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -250,6 +250,160 @@ def modsGlobal :=
     )"
   ]
 
+def modsNumeric :=
+  [
+    ------------------- ibinops ---------------------
+    "(module
+        (func (param i32 i32) (result i32)
+          (i32.add (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.sub (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.mul (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.div_s (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.div_u (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.rem_s (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.rem_u (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.and (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.or (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.xor (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.shl (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.shr_u (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.shr_s (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (local.get 0) (i32.rotl)
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.rotr (local.get 0) (local.get 1))
+        )
+    )"
+    ------------------- iunops ---------------------
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.clz (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.ctz)
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.popcnt (local.get 1))
+        )
+    )"
+    ------------------- itestop ---------------------
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.eqz)
+        )
+    )"
+    ------------------- irelops ---------------------
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.eq (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.ne (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.lt_u (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.lt_s (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.gt_u (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.gt_s (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.le_u (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.le_s (local.get 0))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (i32.ge_u (local.get 0) (local.get 1))
+        )
+    )"
+  , "(module
+        (func (param i32 i32) (result i32)
+          (local.get 1) (i32.ge_s (local.get 0))
+        )
+    )"
+
+  ]
+
 def meaningfulPrograms :=
 [
   "(module
@@ -353,7 +507,8 @@ def doesWasmSandboxRun? :=
   run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
 
 def withWasmSandboxRun : IO UInt32 :=
-  let testCases := [ uWasmMods, modsControl, modsLocal, modsGlobal ]
+  let testCases :=
+    [ uWasmMods, modsControl, modsLocal, modsGlobal, modsNumeric ]
   -- TODO: test meaningful programs
   lspecEachIO testCases.join moduleTestSeq
 

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -117,6 +117,7 @@ def uWasmMods := [
     "(module
         ( func )
       )",
+    "(module)",
     "(module
       (func $main (export \"main\")
         (param $x i32)

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -149,6 +149,7 @@ def uWasmMods := [
 
 def modsControl :=
   [ "(module (func) (func (nop)))"
+  , "(module (func (result i32) (i32.const 0)) (func (result i32) (i32.const 1)))" -- Here we check if non-0-output function return types are also mashed together.
   , "(module (func (result i32)
         (block (result i32) (i32.const 3))
      ))"
@@ -241,7 +242,11 @@ def doesWasmSandboxRun? :=
   run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
 
 def withWasmSandboxRun : IO UInt32 :=
+<<<<<<< HEAD
   let testCases := [ uWasmMods, modsControl, modsLocal, modsGlobal ]
+=======
+  let testCases := [ uWasmMods, modsControl, modsLocal ]
+>>>>>>> b5e870b (Hypothesis: All the duplicate types should be "compressed")
   lspecEachIO testCases.join moduleTestSeq
 
 def withWasmSandboxFail : IO UInt32 :=

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -171,12 +171,50 @@ def modsControl :=
      ))"
   ]
 
+def modsLocal :=
+  [
+    "(module (func (export \"type-local-i32\") (result i32)
+        (local i32) (local.get 0)
+      ))"
+  , "(module (func (export \"type-param-i64\") (param i64) (result i64)
+         (local.get 0)
+      ))"
+  , "(module (func (param i32) (result i32)
+        (loop (result i32) (local.get 0))
+      ))"
+  , "(module (func (param i32) (result i32)
+        (block (result i32) (local.get 0) (i32.const 1) (br_if 0))
+      ))"
+  , "(module (func (result i32) (local $a i32)
+        (block (result i32) (local.get $a) (local.get 0) (br_if 0))
+      ))"
+  , "(module (func (export \"as-block-value\") (param i32)
+        (block (i32.const 1) (local.set 0))
+  ))"
+  , "(module (func (param i32)
+        (loop (i32.const 3) (local.set 0))
+  ))"
+  , "(module (func (param i32)
+        (if (local.get 0) (then) (else (local.set 0) (i32.const 1)))
+  ))"
+  , "(module (func (param i32) (result i32)
+        (i32.ne (i32.const 10) (local.tee 0))
+  ))"
+  , "(module (func (export \"type-mixed\") (param i64 f32 f64 i32 i32) (local f32 i64 i64 f64)
+    (drop) (i64.const 0) (i64.eqz (local.tee 0))
+    (drop) (i32.const 0) (i32.eqz (local.tee 3))
+    (drop) (i32.const 0) (i32.eqz (local.tee 4))
+    (drop) (i64.const 0) (i64.eqz (local.tee 6))
+    (drop) (i64.const 0) (i64.eqz (local.tee 7))
+  ))"
+  ]
+
 open IO.Process (run) in
 def doesWasmSandboxRun? :=
   run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
 
 def withWasmSandboxRun : IO UInt32 :=
-  let testCases := [ uWasmMods, modsControl ]
+  let testCases := [ uWasmMods, modsControl, modsLocal ]
   lspecEachIO testCases.join moduleTestSeq
 
 def withWasmSandboxFail : IO UInt32 :=

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -117,6 +117,9 @@ def uWasmMods := [
     "(module
         ( func )
       )",
+    "(module
+        ( func ) (func $x)
+      )",
     "(module)",
     "(module
       (func $main (export \"main\")
@@ -235,6 +238,16 @@ def modsGlobal :=
          (i32.mul (global.get $x) (global.get $x))
        )
      )"
+  , "(module
+        (global $a i32 (i32.const -2))
+        (func $f (param $x i32)
+                 (result i32)
+
+                 (global.get $a)
+                 (local.set 0)
+                 (local.get $x)
+        )
+    )"
   ]
 
 open IO.Process (run) in

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -8,45 +8,16 @@ open Megaparsec.Parsec
 open Wasm.Wast.Parser
 open Wasm.Bytes
 
--- Success and failure
-structure Success where
-  stdout : String
-  stderr : String
+inductive ExternalFailure (e : IO.Error) : Prop
+instance : Testable (ExternalFailure e) := .isFailure s!"External failure: {e}"
 
-structure Failure where
-  stdout : String
-  stderr : String
-  exitCode : UInt32
+open Megaparsec.Errors.Bundle in
+inductive ParseFailure (src : String) (e : ParseErrorBundle Char String Unit) : Prop
+instance : Testable (ParseFailure src e) := .isFailure s!"Parsing:\n{src}\n{e}"
 
-structure Fault where
-  error : IO.Error
-
-def run (args : IO.Process.SpawnArgs)
-  : IO $ Except (Except Fault Failure) Success := do
-  match (← IO.Process.output args |>.toBaseIO) with
-  | .ok out =>
-    if out.exitCode = 0 then
-      pure $ .ok $ Success.mk out.stdout out.stderr
-    else
-      pure $ .error $ .ok $ Failure.mk out.stdout out.stderr out.exitCode
-  | .error err => pure $ .error $ .error $ Fault.mk err
-
-def doesWasmSandboxRun? := do
-  run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] }
-
-def w2b (x : String) := do
-  run { cmd := "./wasm-sandbox", args := #["wast2bytes", x] }
-
-def testCanary : TestSeq :=
-  test "This is a canary test. Chirp chirp." true
-
-def testCrow : TestSeq :=
-  -- test "This is a crow test. Caw caw." false
-  test
-    "You need to have `wasm-sandbox` binary in your current work directory.
-    Please run:
-    wget https://github.com/cognivore/wasm-sandbox/releases/download/v1/wasm-sandbox && chmod +x ./wasm-sandbox"
-    false
+open IO.Process (run) in
+def w2b (x : String) :=
+  run { cmd := "./wasm-sandbox", args := #["wast2bytes", x] } |>.toBaseIO
 
 -- A very bad hasing function. It adds up the character codes of each of the string's characters, and then appends 'L' followed by the number of characters in the string to reduce the chance of collisions.
 def myHash (s : String) : String :=
@@ -55,6 +26,56 @@ def myHash (s : String) : String :=
 
 def fname (s : String) : String :=
   "./wast-dump-" ++ myHash s ++ ".bytes"
+
+/- Generic Wasm module test. -/
+partial def testGeneric : String → ByteArray → ByteArray → TestSeq
+  | mod, rs, os =>
+    let str := s!"Binary representation is compatible with {fname mod}
+    === CODE ===
+    {mod}
+    ||| END OF CODE |||"
+    test str $ rs = os
+
+/- Here's how Main used to test a particular module:
+
+  IO.println s!"{i} is represented as:"
+  let o_parsed_module ← parseTestP moduleP i
+  match o_parsed_module.2 with
+  | .error _ => IO.println "FAIL"
+  | .ok parsed_module => do
+    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
+    let f := System.mkFilePath ["/tmp", "mtob.41.wasm"]
+    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
+    h.write $ mtob parsed_module
+    gO.println "It's recorded to disk at /tmp/mtob.41.wasm"
+
+Instead of this, here, we're going to:
+
+ 1. Make the reference WASM bytes with `wasm-sandbox` invocation,
+    as provided by function `w2b`.
+ 2. Read the reference bytes into a variable.
+ 3. Compile our bytes and read those into a variable.
+ 4. Write our bytes into a file called s!"{fname}.lean".
+ 5. Byte by byte, compare the two variables, reporting errors.
+-/
+open IO.FS in
+partial def moduleTestSeq (x : String) : IO TestSeq := do
+  -- Run w2b against x
+  match ←w2b x with
+  | .ok _ => do
+    -- Read the reference bytes into a variable.
+    let ref_bytes ← readBinFile $ fname x
+    -- Compile our bytes and read those into a variable.
+    match parse moduleP x with
+    | .error pe =>
+      pure $ test "parsing module" (ParseFailure x pe)
+    | .ok module => do
+      let our_bytes := mtob module
+      -- Write our bytes into a file called s!"{fname}.lean".
+      writeBinFile s!"{fname x}.lean" our_bytes
+      pure $ testGeneric x ref_bytes our_bytes
+  | .error e =>
+    pure $ test "failed to encode with wasm-sandbox" (ExternalFailure e)
 
 def uWasmMods := [
   "(module
@@ -128,71 +149,21 @@ def uWasmMods := [
     ))"
 ]
 
-/- Generic Wasm module test that uses loop to check for stuff. -/
-partial def testGeneric : String → ByteArray → ByteArray → TestSeq
-  | mod, rs, os =>
-    let str := s!"Binary representation is compatible with {fname mod}
-    === CODE ===
-    {mod}
-    ||| END OF CODE |||"
-    test str $ rs = os
-
-/- Here's how Main used to test a particular module:
-
-  IO.println s!"{i} is represented as:"
-  let o_parsed_module ← parseTestP moduleP i
-  match o_parsed_module.2 with
-  | .error _ => IO.println "FAIL"
-  | .ok parsed_module => do
-    IO.println s!">>> !!! >>> It is converted to bytes as: {mtob parsed_module}"
-    let f := System.mkFilePath ["/tmp", "mtob.41.wasm"]
-    let h ← IO.FS.Handle.mk f IO.FS.Mode.write
-    h.write $ mtob parsed_module
-    gO.println "It's recorded to disk at /tmp/mtob.41.wasm"
-
-Instead of this, here, we're going to:
-
- 1. Make the reference WASM bytes with `wasm-sandbox` invocation,
-    as provided by function `w2b`.
- 2. Read the reference bytes into a variable.
- 3. Compile our bytes and read those into a variable.
- 4. Write our bytes into a file called s!"{fname}.lean".
- 5. Byte by byte, compare the two variables, reporting errors.
--/
-partial def moduleTestIO (x : String) : IO UInt32 := do
-  -- Run w2b against x
-  -- If we failed for any reason, we return false, otherwise, we go ahead to the next step, encoded as another function.
-  match (← w2b x) with
-  | .error _ =>
-    pure 35
-  | .ok _w2b_x => do
-    -- Read the reference bytes into a variable.
-    let ref_bytes ← IO.FS.Handle.mk (fname x) IO.FS.Mode.read >>=
-      fun h => h.readBinToEnd
-    -- Compile our bytes and read those into a variable.
-    match parseP moduleP "" x with
-    | .error _ =>
-      pure 55
-    | .ok parsed_module => do
-      let our_bytes := mtob parsed_module
-      -- Write our bytes into a file called s!"{fname}.lean".
-      let h ← IO.FS.Handle.mk s!"{fname x}.lean" IO.FS.Mode.write
-      h.write our_bytes
-      lspecIO $ testGeneric x ref_bytes our_bytes
-
-def preservingErrorCode (acc : UInt32) (x : IO UInt32) : IO UInt32 := do
-  match (← x) with
-  | 0 => pure acc
-  | n => pure n
+open IO.Process (run) in
+def doesWasmSandboxRun? :=
+  run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
 
 def withWasmSandboxRun : IO UInt32 :=
-  -- For each element in uWasmMods, run moduleTestIO on it.
-  uWasmMods.foldlM (fun acc x => preservingErrorCode acc $ moduleTestIO x) 0
+  let testCases := [ uWasmMods ]
+  lspecEachIO testCases.join moduleTestSeq
 
 def withWasmSandboxFail : IO UInt32 :=
-  lspecIO $ testCrow
+  lspecIO $ test "wasm-sandbox check"
+    (ExternalFailure "You need to have `wasm-sandbox` binary in your current work directory.
+    Please run:
+    wget https://github.com/cognivore/wasm-sandbox/releases/download/v1/wasm-sandbox && chmod +x ./wasm-sandbox")
 
 def main : IO UInt32 := do
   match (← doesWasmSandboxRun?) with
-  | Except.ok _ => withWasmSandboxRun
+  | .ok _ => withWasmSandboxRun
   | _ => withWasmSandboxFail

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -144,18 +144,39 @@ def uWasmMods := [
         )
 
       )
-    )",
-    "(module (func (result i32)
-        (block (result i32) (i32.const 3))
-    ))"
+    )"
 ]
+
+def modsControl :=
+  [ "(module (func) (func (nop)))"
+  , "(module (func (result i32)
+        (block (result i32) (i32.const 3))
+     ))"
+  , "(module (func (result i32)
+        (if (result i32) (i32.const 0)
+          (then (i32.const 1)) (else (i32.const 0))
+        )
+     ))"
+  , "(module (func (result i32)
+        (loop (result i32) (i32.const 3))
+     ))"
+  , "(module (func (result i64)
+        (block (result i64)
+          (i64.const 6)
+          (i64.add (br 0))
+        )
+     ))"
+  , "(module (func (result i32)
+        (block (result i32) (i32.ctz (br_if 0)))
+     ))"
+  ]
 
 open IO.Process (run) in
 def doesWasmSandboxRun? :=
   run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
 
 def withWasmSandboxRun : IO UInt32 :=
-  let testCases := [ uWasmMods ]
+  let testCases := [ uWasmMods, modsControl ]
   lspecEachIO testCases.join moduleTestSeq
 
 def withWasmSandboxFail : IO UInt32 :=

--- a/Tests/SimpleEncodings.lean
+++ b/Tests/SimpleEncodings.lean
@@ -123,7 +123,7 @@ def testBlockResultConstEndParses : TestSeq :=
 def testIfParses : TestSeq :=
   test "if (result i32) then (i32.const 42) else (i32.const 9) parses" $
     testParse ifP "if (result i32) then (i32.const 42) else (i32.const 9)" $
-      (.if [(Type'.i 32)] [(.const (Type'.i 32) (.i (ConstInt.mk 32 42)))]
+      (.if [(Type'.i 32)] (.from_stack) [(.const (Type'.i 32) (.i (ConstInt.mk 32 42)))]
            [(.const (Type'.i 32) (.i (ConstInt.mk 32 9)))])
 
 def testAFuncWithImplementationParses : TestSeq :=

--- a/Tests/SimpleEncodings.lean
+++ b/Tests/SimpleEncodings.lean
@@ -8,25 +8,28 @@ open LSpec
 open Megaparsec.Parsec
 open Wasm.Wast.Parser
 
-def isOkAndBEq (x : Except ε α) (y : α) [BEq α] : Bool :=
-  match x with
-  | .ok actual => y == actual
-  | .error _ => false
+open Megaparsec.Errors.Bundle in
+inductive ParseFailure (src : String) (e : ParseErrorBundle Char String Unit) : Prop
+instance : Testable (ParseFailure src e) := .isFailure s!"Parsing:\n{src}\n{e}"
 
 def testParse (parser: Parsec Char String Unit α)
-              (x : String) (y : α) [BEq α] : Bool :=
-  isOkAndBEq (parse parser x) y
+              (src : String) (y : α) [BEq α] [ToString α] : TestSeq :=
+  match parse parser src with
+  | .error pe => test "parsing failed" (ParseFailure src pe)
+  | .ok x =>
+    if x == y
+    then test src true
+    else test "doesn't match" (ExpectationFailure s!"{y}" s!"{x}")
 
 open Wasm.Wast.AST.Type'.Type'
 
 def testFisF : TestSeq :=
-  test "f32 parses to .f 32" $ testParse typeP "f32" (f 32)
+  testParse typeP "f32" (f 32)
 
 open Wasm.Wast.Num.Num.Int
 
 def testMinusOneisI32MinusOne : TestSeq :=
-  test "parse 'i32 const -1'" $
-    testParse iP "i32.const -1" ⟨ 32, -1 ⟩
+  testParse iP "i32.const -1" ⟨ 32, -1 ⟩
 
 open Wasm.Wast.AST.Operation
 open Wasm.Wast.AST.Type'
@@ -52,105 +55,86 @@ instance : BEq Operation where
   beq := (toString · == toString ·)
 
 def testAdd42IsOpAddConstStack : TestSeq :=
-  test "'i32.add (i32.const 42)' parses to '.add (.i 32) (Get'.from_operation (ConstInt 32 42)) (Get'.from_stack)'" $
-    testParse (binopP "add" .add) "i32.add (i32.const 42)" $
-      Operation.add (.i 32)
-                    (.from_operation (.const (.i 32) (.i ⟨ 32, 42 ⟩ )))
-                    (.from_stack)
-
-def testAdd42IsntOpAddWrongConstStack : TestSeq :=
-  test "'i32.add (i32.const 42)' DOES NOT parse to '.add (.i 32) (Get'.from_operation (ConstInt 32 420)) (Get'.from_stack)'" $
-    let unexpect :=
-      Operation.add (.i 32)
-                    (.from_operation (.const (.i 32) (.i ⟨ 32, 420 ⟩ )))
-                    (.from_stack)
-    not (testParse (binopP "add" .add) "i32.add (i32.const 42)" $ unexpect)
+  testParse (binopP "add" .add) "i32.add (i32.const 42)" $
+    Operation.add (.i 32)
+                  (.from_operation (.const (.i 32) (.i ⟨ 32, 42 ⟩ )))
+                  (.from_stack)
 
 open Wasm.Wast.AST.Func
+open Wasm.Wast.AST.Local
 
 instance : BEq Func where
   beq := (toString · == toString ·)
 
-def testFuncIsFunc : TestSeq :=
-  test "(func) is (Func.mk none none [] [] [] [])" $ testParse funcP "(func)" (Func.mk .none .none [] [] [] [])
-
-open Wasm.Wast.AST.Local
-
 def testParamIsActuallyLocal : TestSeq :=
-  test "param $t i32 is (Local.mk 0 .none (Type'.i 32))" $ testParse paramP "param $t i32" (Local.mk (.some "t") (Type'.i 32))
+  testParse paramP "param $t i32" (Local.mk (.some "t") (Type'.i 32))
 
 def testSomeParamsParse : TestSeq :=
-  test "(param $t i32) (param $coocoo f32) (param i64) parses correctly." $
-    testParse nilParamsP "(param $t i32) (param $coocoo f32) (param i64)" $
-      [Local.mk (.some "t") (Type'.i 32),
-       Local.mk (.some "coocoo") (Type'.f 32),
-       Local.mk .none (Type'.i 64)]
+  testParse nilParamsP "(param $t i32) (param $coocoo f32) (param i64)" $
+    [Local.mk (.some "t") (Type'.i 32),
+      Local.mk (.some "coocoo") (Type'.f 32),
+      Local.mk .none (Type'.i 64)]
 
 def testSpacesAreIgnoredWhileParsingParams : TestSeq :=
-  test "(param i32) (param $coocoo f32)  ( param i64 ) ( something_else ) parses alright" $
-    testParse nilParamsP "(param i32) (param $coocoo f32)  ( param i64 ) ( something_else )" $
-      [Local.mk .none (Type'.i 32),
-       Local.mk (.some "coocoo") (Type'.f 32),
-       Local.mk .none (Type'.i 64)]
+  testParse nilParamsP "(param i32) (param $coocoo f32)  ( param i64 ) ( something_else )" $
+    [Local.mk .none (Type'.i 32),
+    Local.mk (.some "coocoo") (Type'.f 32),
+    Local.mk .none (Type'.i 64)]
 
 def testResultParses : TestSeq :=
-  test "( result i32) parses to [Type'.i 32]" $
-    testParse brResultsP "( result i32)" [Type'.i 32]
-
-def testFuncParses : TestSeq :=
-  test "(func (param $x i32) (param $y i32) (result i32)
-  ) parses" $
-    testParse funcP "(func (param $x i32) (param $y i32) (result i32)
-  )" $ (Func.mk .none .none [(Local.mk (.some "x") (Type'.i 32)), (Local.mk (.some "y") (Type'.i 32))] [(Type'.i 32)] [] [])
-
-def testAnotherFuncParses : TestSeq :=
-  test "(func (param $x i32) (param i32) (result i32)) parses" $
-    testParse funcP "(func (param $x i32) (param i32) (result i32))" $ (Func.mk .none .none [(Local.mk (.some "x") (Type'.i 32)), (Local.mk .none (Type'.i 32))] [(Type'.i 32)] [] [])
-
-def testYetAnotherFuncParses : TestSeq :=
-  test "(func (param $x i32) (param i32) (result i32) (result i64)) parses" $
-    testParse funcP "(func (param $x i32) (param i32) (result i32) (result i64))" $ (Func.mk .none .none [(Local.mk (.some "x") (Type'.i 32)), (Local.mk .none (Type'.i 32))] [(Type'.i 32), (Type'.i 64)] [] [])
-
-def testFlawedFuncDoesntParse : TestSeq :=
-  test "(func func (param $x i32) (param i32) (result i32) (result i64) (result i64)) DOES NOT parse" $
-    not (parses? funcP "(func func (param $x i32) (param i32) (result i32) (result i64) (result i64))")
+  testParse brResultsP "( result i32)" [Type'.i 32]
 
 def testBlockResultConstEndParses : TestSeq :=
-  test "(block (result i32) (i32.const 1) end) parses" $
-    testParse opP "(block (result i32) (i32.const 1) end)" $
-      (.block [(Type'.i 32)] [(.const (Type'.i 32) (.i (ConstInt.mk 32 1)))])
+  testParse opP "(block (result i32) (i32.const 1) end)" $
+    (.block [(Type'.i 32)] [(.const (Type'.i 32) (.i (ConstInt.mk 32 1)))])
 
 def testIfParses : TestSeq :=
-  test "if (result i32) then (i32.const 42) else (i32.const 9) parses" $
-    testParse ifP "if (result i32) then (i32.const 42) else (i32.const 9)" $
-      (.if [(Type'.i 32)] (.from_stack) [(.const (Type'.i 32) (.i (ConstInt.mk 32 42)))]
-           [(.const (Type'.i 32) (.i (ConstInt.mk 32 9)))])
+  testParse ifP "if (result i32) (then (i32.const 42)) (else (i32.const 9))" $
+    (.if [(Type'.i 32)] (.from_stack) [(.const (Type'.i 32) (.i (ConstInt.mk 32 42)))]
+          [(.const (Type'.i 32) (.i (ConstInt.mk 32 9)))])
 
-def testAFuncWithImplementationParses : TestSeq :=
-  test "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2))) parses" $
-    testParse funcP "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))" $
+def testFuncs : TestSeq :=
+  let test' := testParse (bracketed funcP)
+  group "check that functions parse" $
+    test' "(func)" (Func.mk .none .none [] [] [] []) ++
+    test' "(func (param $x i32) (param i32) (result i32))"
       (Func.mk .none .none
-        [(Local.mk (.some "x") (Type'.i 32)), (Local.mk .none (.i 32))]
-        [(.i 32)] []
-        [(.add (.i 32) (.from_operation (.const (.i 32) (.i (ConstInt.mk 32 40))))
-          (.from_operation (.const (.i 32) (.i (ConstInt.mk 32 2))))
-         )])
+        [(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
+        [(.i 32)] [] []
+      ) ++
+    test' "(func (param $x i32) (param i32) (result i32) (result i64))"
+      (Func.mk .none .none
+        [(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
+        [(.i 32), (.i 64)] [] []
+      ) ++
+    test' "(func (param $x i32) (param $y i32) (result i32))"
+      (Func.mk .none .none
+        [ (Local.mk (.some "x") (.i 32)), (Local.mk (.some "y") (.i 32))]
+        [(.i 32)] [] []
+      ) ++
+    test' "(func (param $x i32) (param i32) (result i32) (i32.add (i32.const 40) (i32.const 2)))"
+    (Func.mk .none .none
+      [(Local.mk (.some "x") (.i 32)), (Local.mk .none (.i 32))]
+      [(.i 32)] []
+      [(.add (.i 32) (.from_operation (.const (.i 32) (.i (ConstInt.mk 32 40))))
+        (.from_operation (.const (.i 32) (.i (ConstInt.mk 32 2))))
+        )]
+    )
 
-def main : IO UInt32 := do
+def testFlawedFuncDoesntParse : TestSeq :=
+  test "NO PARSE: (func func (param $x i32) (param i32) (result i32) (result i64) (result i64))" $
+    not (parses? (bracketed funcP) "(func func (param $x i32) (param i32) (result i32) (result i64) (result i64))")
+
+def main : IO UInt32 :=
   lspecIO $
     testFisF ++
     testMinusOneisI32MinusOne ++
     testAdd42IsOpAddConstStack ++
-    testAdd42IsntOpAddWrongConstStack ++
-    testFuncIsFunc ++
     testParamIsActuallyLocal ++
     testSomeParamsParse ++
     testSpacesAreIgnoredWhileParsingParams ++
     testResultParses ++
-    testFuncParses ++
-    testAnotherFuncParses ++
-    testYetAnotherFuncParses ++
-    testFlawedFuncDoesntParse ++
     testBlockResultConstEndParses ++
     testIfParses ++
-    testAFuncWithImplementationParses
+    testFuncs ++
+    testFlawedFuncDoesntParse

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -397,14 +397,15 @@ mutual
       pure $ b 0x02 ++ obs ++ b 0x0b
     | .loop ts ops =>
       let bts := flatten $ ts.map (b ∘ ttoi)
-      let obs ← bts ++ mkVecM ops extractOp
-      pure $ b 0x03 ++ bts ++ lindex obs ++ b 0x0b
-    | .if ts thens elses =>
+      let obs ← bts ++ flatten <$> ops.mapM extractOp
+      pure $ b 0x03 ++ obs ++ b 0x0b
+    | .if ts g thens elses =>
+      let bg ← extractGet' g
       let bts := flatten $ ts.map (b ∘ ttoi)
-      let bth ← mkVecM thens extractOp
+      let bth ← flatten <$> thens.mapM extractOp
       let belse ← if elses.isEmpty then pure b0 else
-        b 0x05 ++ lindex <$> mkVecM elses extractOp
-      pure $ b 0x04 ++ bts ++ lindex (bth ++ belse) ++ b 0x0b
+        b 0x05 ++ flatten <$> elses.mapM extractOp
+      pure $ bg ++ b 0x04 ++ bts ++ bth ++ belse ++ b 0x0b
     | .br li => pure $ b 0x0c ++ sLeb128 li
     | .br_if li => pure $ b 0x0d ++ sLeb128 li
 

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -530,7 +530,7 @@ def extractGlobal (g : Global) : ByteArray :=
   egt ++ einit ++ b 0x0b
 
 def extractGlobals : List Global → ByteArray :=
-  enf (b 0x06 ++ ·) (mkVec · extractGlobal)
+  enf (b 0x06 ++ lindex ·) (mkVec · extractGlobal)
 
 def encodeLocal (l : Nat × Local) : ByteArray :=
   match l.2.name with

--- a/Wasm/Bytes.lean
+++ b/Wasm/Bytes.lean
@@ -421,16 +421,18 @@ def extractFuncTypes (f : Func) : ByteArray :=
   header ++ params ++ result
 
 def extractTypes (m : Module) : ByteArray :=
-  let header := b 0x01
-  let funcs := mkVec m.func extractFuncTypes
-  header ++ lindex funcs
+  if m.func.isEmpty then b0 else
+    let header := b 0x01
+    let funcs := mkVec m.func extractFuncTypes
+    header ++ lindex funcs
 
 /- Function section -/
 def extractFuncIds (m : Module) : ByteArray :=
-  let funs :=
+  if m.func.isEmpty then b0 else
+    let funs :=
     uLeb128 m.func.length ++
     m.func.foldl (fun acc _x => acc ++ b acc.data.size.toUInt8) b0
-  b 0x03 ++ lindex funs
+    b 0x03 ++ lindex funs
 
 def extractFuncBody (globals : Globals) (f : Func) : ByteArray :=
   -- Locals are encoded with counts of subgroups of the same type.
@@ -447,9 +449,10 @@ def extractFuncBody (globals : Globals) (f : Func) : ByteArray :=
   lindex $ locals ++ obs ++ b 0x0b
 
 def extractFuncBodies (m : Module) : ByteArray :=
-  let header := b 0x0a
-  let extractFBwGlobals := extractFuncBody $ indexIdentifiedGlobals m.globals
-  header ++ lindex (mkVec m.func extractFBwGlobals)
+  if m.func.isEmpty then b0 else
+    let header := b 0x0a
+    let extractFBwGlobals := extractFuncBody $ indexIdentifiedGlobals m.globals
+    header ++ lindex (mkVec m.func extractFBwGlobals)
 
 def modHeader : ByteArray := b 0x00
 

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -113,7 +113,9 @@ mutual
 -- can't be populated with `ConstFloat`!
   inductive Operation where
   | nop
+  --------------------- PARAMETRIC ----------------------
   | drop
+  ----------------------  NUMERIC -----------------------
   | const : Type' → NumUniT → Operation
   | eqz : Type' → Get' → Operation
   | eq  : Type' → Get' → Get' → Operation
@@ -151,14 +153,16 @@ mutual
   | shr_s : Type' → Get' → Get' → Operation
   | rotl : Type' → Get' → Get' → Operation
   | rotr : Type' → Get' → Get' → Operation
+  ---------------------- VARIABLE -----------------------
   | local_get : LocalLabel → Operation
   | local_set : LocalLabel → Operation
   | local_tee : LocalLabel → Operation
   | global_get : GlobalLabel → Operation
   | global_set : GlobalLabel → Operation
+  ----------------------- CONTROL -----------------------
   | block : List Type' → List Operation → Operation
   | loop : List Type' → List Operation → Operation
-  | if : List Type' → List Operation → List Operation → Operation
+  | if : List Type' → Get' → List Operation → List Operation → Operation
   | br : LabelIndex → Operation
   | br_if : LabelIndex → Operation
 end
@@ -231,7 +235,7 @@ mutual
     | .global_set l => s!"(Operation.global_set {l})"
     | .block ts is => s!"(Operation.block {ts} {is.map operationToString})"
     | .loop ts is => s!"(Operation.loop {ts} {is.map operationToString})"
-    | .if ts thens elses => s!"(Operation.if {ts} {thens.map operationToString} {elses.map operationToString})"
+    | .if ts g thens elses => s!"(Operation.if {ts} {getToString g} {thens.map operationToString} {elses.map operationToString})"
     | .br li => s!"(Operation.br {li})"
     | .br_if li => s!"(Operation.br_if {li})"
 

--- a/Wasm/Wast/AST.lean
+++ b/Wasm/Wast/AST.lean
@@ -302,7 +302,7 @@ structure Module where
   func : List Func
 
 instance : ToString Module where
-  toString x := s!"(Module.mk {x.name} {x.func})"
+  toString x := s!"(Module.mk {x.name} {x.globals} {x.func})"
 
 end Module
 

--- a/Wasm/Wast/Num.lean
+++ b/Wasm/Wast/Num.lean
@@ -35,6 +35,27 @@ def toNBits (i : Int) (size : BitSize := 64) : List Bit :=
   let padbit := if i ≥ 0 then .zero else .one
   List.replicate (size - bits.length) padbit ++ bits
 
+def UInt8.toHexString (n : UInt8) : String :=
+  let toLetter
+    | 10 => "a"
+    | 11 => "b"
+    | 12 => "c"
+    | 13 => "d"
+    | 14 => "e"
+    | 15 => "f"
+    | n => toString n
+  "0x" ++ toLetter (n / 16) ++ toLetter (n % 16)
+
+def ByteArray.toHexString (bs : ByteArray) : String := Id.run do
+  if bs.isEmpty then "b[]" else
+  let mut ans := "b["
+  for u in bs do
+    ans := ans ++ UInt8.toHexString u ++ ", "
+  return ans.dropRight 2 ++ "]"
+
+instance : Repr ByteArray where
+  reprPrec bs _ := ByteArray.toHexString bs
+
 namespace Wasm.Wast.Num
 
 namespace NumType

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -180,7 +180,7 @@ private def brOpP : Parsec Char String Unit Operation := do
     let type : Type' ←
       string s!"i32.{opS}" *> (pure $ .i 32) <|>
       string s!"i64.{opS}" *> (pure $ .i 64)
-    ignoreP
+    owP
     let arg ← getP
     owP
     pure $ unopMk type arg
@@ -193,7 +193,7 @@ private def brOpP : Parsec Char String Unit Operation := do
     let type ←
       string s!"{tChar}32.{opS}" *> (pure $ con 32) <|>
       string s!"{tChar}64.{opS}" *> (pure $ con 64)
-    ignoreP
+    owP
     let arg_1 ← getP
     owP
     let arg_2 ← getP

--- a/Wasm/Wast/Parser.lean
+++ b/Wasm/Wast/Parser.lean
@@ -38,8 +38,38 @@ open Operation
 open Func
 open Module
 
-def manyLispP (p : Parsec Char String Unit α) : Parsec Char String Unit (List α) :=
-  sepEndBy' (attempt (single '(' *> owP *> p <* owP <* single ')')) owP
+def bracketed (p : Parsec Char String Unit α) :=
+  Seq.between (single '(' *> owP) (owP <* single ')') p
+
+def bracketedWs (p : Parsec Char String Unit α) :=
+  owP *> bracketed p <* owP
+
+def oneOfTwoP (pa : Parsec Char String Unit α)
+              (pb : Parsec Char String Unit β)
+    : Parsec Char String Unit (Except α β) :=
+  .error <$> pa <|> .ok <$> pb
+
+/- Sometimes – mainly for module parsing, where declarations can be
+  arbitrarily interspersed – we need a way to parse a mix of parsers.
+
+  Additionally, and crucially, we don't want to use `attempt`, as it
+  messes with error reporting.
+
+  Consider that the "common prefix" we
+  would use `attempt` for, brackets, is always known.
+-/
+def mixOfTwoLispP (pa : Parsec Char String Unit α)
+                  (pb : Parsec Char String Unit β)
+    : Parsec Char String Unit (List α × List β) := do
+  let mix ← sepEndBy' (bracketed (oneOfTwoP pa pb)) owP
+  let either exc acc := match exc with
+    | .error a => (a :: acc.1, acc.2)
+    | .ok b => (acc.1, b :: acc.2)
+  pure $ mix.foldr either ([],[])
+
+def manyLispP (p : Parsec Char String Unit α)
+    : Parsec Char String Unit (List α) :=
+  sepEndBy' (attempt (bracketed p)) owP
 
 def typeP : Parsec Char String Unit Type' := do
   let ps ← getParserState
@@ -60,9 +90,6 @@ def globalLabelP : Parsec Char String Unit GlobalLabel :=
 
 def resultP : Parsec Char String Unit (List Type') :=
   string "result" *> ignoreP *> sepEndBy' typeP owP
-
-def brResultP : Parsec Char String Unit (List Type') :=
-  single '(' *> owP *> resultP <* owP <* single ')'
 
 def brResultsP : Parsec Char String Unit (List Type') :=
   List.join <$> manyLispP resultP
@@ -103,32 +130,29 @@ private def brifP : Parsec Char String Unit Operation := do
  mutual
 
   partial def getP : Parsec Char String Unit Get' :=
-    attempt (pure ∘ .from_operation =<< opP) <|>
-    pure .from_stack
+    (.from_operation <$> attempt opP) <|> pure .from_stack
 
-  partial def opP : Parsec Char String Unit Operation :=
-    Char.between '(' ')' $ owP *>
-      nopP <|> dropP <|> constP <|>
-      iUnopP "eqz" .eqz <|>
-      binopP "eq" .eq <|> binopP "ne" .ne <|>
-      iBinopP "lt_u" .lt_u <|> iBinopP "lt_s" .lt_s <|>
-      iBinopP "gt_u" .gt_u <|> iBinopP "gt_s" .gt_s <|>
-      iBinopP "le_u" .le_u <|> iBinopP "le_s" .le_s <|>
-      iBinopP "ge_u" .ge_u <|> iBinopP "ge_s" .ge_s <|>
-      fBinopP "lt" .lt <|> fBinopP "gt" .gt <|>
-      fBinopP "le" .le <|> fBinopP "ge" .ge <|>
-      iUnopP "clz" .clz <|> iUnopP "ctz" .ctz <|> iUnopP "popcnt" .popcnt <|>
-      binopP "add" .add <|> binopP "sub" .sub <|> binopP "mul" .mul <|>
-      fBinopP "div" .div <|> fBinopP "max" .max <|> fBinopP "min" .min <|>
-      iBinopP "div_s" .div_s <|> iBinopP "div_u" .div_u <|>
-      iBinopP "rem_s" .rem_s <|> iBinopP "rem_u" .rem_u <|>
-      iBinopP "and" .and <|> iBinopP "or" .or <|> iBinopP "xor" .xor <|>
-      iBinopP "shl" .shl <|>
-      iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
-      iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
-      localOpP <|> globalOpP <|> blockP <|> loopP <|> ifP <|>
-      brP <|> brifP
-      <* owP
+  partial def opP : Parsec Char String Unit Operation := bracketed $
+    nopP <|> dropP <|> constP <|>
+    iUnopP "eqz" .eqz <|>
+    binopP "eq" .eq <|> binopP "ne" .ne <|>
+    iBinopP "lt_u" .lt_u <|> iBinopP "lt_s" .lt_s <|>
+    iBinopP "gt_u" .gt_u <|> iBinopP "gt_s" .gt_s <|>
+    iBinopP "le_u" .le_u <|> iBinopP "le_s" .le_s <|>
+    iBinopP "ge_u" .ge_u <|> iBinopP "ge_s" .ge_s <|>
+    fBinopP "lt" .lt <|> fBinopP "gt" .gt <|>
+    fBinopP "le" .le <|> fBinopP "ge" .ge <|>
+    iUnopP "clz" .clz <|> iUnopP "ctz" .ctz <|> iUnopP "popcnt" .popcnt <|>
+    binopP "add" .add <|> binopP "sub" .sub <|> binopP "mul" .mul <|>
+    fBinopP "div" .div <|> fBinopP "max" .max <|> fBinopP "min" .min <|>
+    iBinopP "div_s" .div_s <|> iBinopP "div_u" .div_u <|>
+    iBinopP "rem_s" .rem_s <|> iBinopP "rem_u" .rem_u <|>
+    iBinopP "and" .and <|> iBinopP "or" .or <|> iBinopP "xor" .xor <|>
+    iBinopP "shl" .shl <|>
+    iBinopP "shr_u" .shr_u <|> iBinopP "shr_s" .shr_s <|>
+    iBinopP "rotl" .rotl <|> iBinopP "rotr" .rotr <|>
+    localOpP <|> globalOpP <|>
+    blockP <|> loopP <|> ifP <|> brifP <|> brP
 
   partial def opsP : Parsec Char String Unit (List Operation) := do
     sepEndBy' opP owP
@@ -137,14 +161,14 @@ private def brifP : Parsec Char String Unit Operation := do
     string "block" *> ignoreP
     let ts ← brResultsP
     let ops ← opsP
-    owP <* option' (string "end")
+    discard $ option' (string "end")
     pure $ .block ts ops
 
   partial def loopP : Parsec Char String Unit Operation := do
     string "loop" *> ignoreP
     let ts ← brResultsP
     let ops ← opsP
-    owP <* option' (string "end")
+    discard $ option' (string "end")
     pure $ .loop ts ops
 
   partial def ifP : Parsec Char String Unit Operation := do
@@ -195,12 +219,11 @@ private def brifP : Parsec Char String Unit Operation := do
 end
 
 
-def exportP : Parsec Char String Unit String :=
-  Char.between '(' ')' $
-    string "export" *> ignoreP *>
-    -- TODO: are escaped quotation marks legal export names?
-    let export_label := Char.between '\"' '\"' $ many' $ noneOf "\"".data
-    String.mk <$> export_label
+def exportP : Parsec Char String Unit String := bracketed $
+  string "export" *> ignoreP *>
+  -- TODO: are escaped quotation marks legal export names?
+  let export_label := Char.between '\"' '\"' $ many' $ noneOf "\"".data
+  String.mk <$> export_label
 
 def genLocalP (x : String) : Parsec Char String Unit Local :=
   string x *> ignoreP *>
@@ -219,9 +242,10 @@ def nilLocalsP : Parsec Char String Unit (List Local) :=
   manyLispP localP
 
 def globalTypeP : Parsec Char String Unit GlobalType :=
-  let mutP := owP *> string "mut" *> ignoreP
-  (GlobalType.mk false <$> typeP) <|>
-  (Char.between '(' ')' $ GlobalType.mk true <$> (mutP *> typeP))
+  let mutP := string "mut" *> ignoreP
+  let constTP := GlobalType.mk false <$> typeP
+  let varTP := bracketed $ GlobalType.mk true <$> (mutP *> typeP)
+  constTP <|> varTP
 
 /-
 TODO: the initial expression for a global has to be a constant expression.
@@ -232,43 +256,36 @@ when we add support for:
 - imports: it also accepts `global.get i` where `i`s init is of constP form
 see https://webassembly.github.io/spec/core/valid/instructions.html#constant-expressions
 -/
-def globalP : Parsec Char String Unit Global :=
-  Char.between '(' ')' do
-    owP *> string "global" *> ignoreP
-    let oname ← option' (nameP <* ignoreP)
-    let gt ← globalTypeP
-    let init ← ignoreP *>
-      Char.between '(' ')' (owP *> constP <* owP)
-    pure ⟨oname, gt, init⟩
+def globalP : Parsec Char String Unit Global := do
+  string "global" *> ignoreP
+  let oname ← option' (nameP <* ignoreP)
+  let gt ← globalTypeP <* ignoreP
+  let init ← bracketed constP
+  pure ⟨oname, gt, init⟩
 
-def funcP : Parsec Char String Unit Func :=
-  Char.between '(' ')' do
-    owP <* (string "func")
-    -- let oname ← option' (ignoreP *> nameP)
-    let oname ← option' (attempt $ ignoreP *> nameP)
-    let oexp ← option' (attempt $ owP *> exportP)
-    let ops ← option' (attempt $ owP *> nilParamsP)
-    let ps := optional ops []
-    let rtypes ← attempt $ owP *> brResultsP
-    let ols ← option' (attempt $ owP *> nilLocalsP)
-    let ls := optional ols []
-    let oops ← option' (attempt $ owP *> opsP)
-    let ops := optional oops []
-    owP
-    pure $ Func.mk oname oexp ps rtypes ls ops
+def funcP : Parsec Char String Unit Func := do
+  -- either we have a trivial case `(func)` or we must parse whitespace
+  discard $ string "func"
+  let oname ← option' (attempt (ignoreP *> nameP))
+  let oexp ← owP *> option' (attempt exportP <* owP)
+  let ops ← option' nilParamsP
+  let ps := optional ops []
+  let rtypes ← brResultsP
+  let ols ← option' nilLocalsP
+  let ls := optional ols []
+  let oops ← option' opsP
+  let ops := optional oops []
+  pure $ Func.mk oname oexp ps rtypes ls ops
 
--- TODO: A module consists of a sequence of fields that can occur in any order. -- All definitions and their respective bound identifiers scope over the entire
+-- NB: A module consists of a sequence of fields that can occur in any order.
+-- All definitions and their respective bound identifiers scope over the entire
 -- module, including the text preceding them.
-def moduleP : Parsec Char String Unit Module :=
-  Char.between '(' ')' do
-    owP <* string "module"
-    let oname ← option' (attempt $ ignoreP *> nameP)
-    let oglobals ← option' (ignoreP *> sepEndBy' (attempt globalP) owP)
-    let globals := optional oglobals []
-    let ofuns ← option' (attempt $ owP *> sepEndBy' funcP owP)
-    let funs := optional ofuns []
-    owP
-    pure $ Module.mk oname globals funs
+def moduleP : Parsec Char String Unit Module := bracketedWs do
+  discard $ string "module"
+  let oname ← option' (attempt (ignoreP *> nameP))
+  let (globals, funs) ← owP *> mixOfTwoLispP globalP funcP
+
+  pure $ Module.mk oname globals funs
 
 
 end textparser


### PR DESCRIPTION
1. Added tests for:
- control instructions (`nop, block, loop, if, br, br_if`)
- local instructions (`local.get, local.set, local.tee`). Closes #43 
- global instructions (`global.get, global.set`)
- numeric instructions for ints (`const, eqz, eq, ne, lt_u, lt_s, gt_u, gt_s, le_u, le_s, ge_u, ge_s,
clz, ctz, popcnt, add, sub, mul, div_s, div_u, rem_s, rem_u,
and, or, xor, shl, shr_u, shr_s, rotl, rotr`)

2. Fixed all the bugs discovered by these tests.
3. Improved our AST parser, in particular to report errors more accurately, a long-standing issue.
4. Improved existing tests by:
- rewriting the framework for binary compatibility tests to use more LSpec. Closes #39
- rewriting simple encodings tests to report more information.