### PR TITLE
[#46] Support ids for structured control instructions

### DIFF
--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -31,9 +31,7 @@ def fname (s : String) : String :=
 partial def testGeneric : String → ByteArray → ByteArray → TestSeq
   | mod, rs, os =>
     let str := s!"Binary representation is compatible with {fname mod}
-    === CODE ===
-    {mod}
-    ||| END OF CODE |||"
+    {mod}"
     test str $ rs = os
 
 /- Here's how Main used to test a particular module:
@@ -75,7 +73,7 @@ partial def moduleTestSeq (x : String) : IO TestSeq := do
       writeBinFile s!"{fname x}.lean" our_bytes
       pure $ testGeneric x ref_bytes our_bytes
   | .error e =>
-    pure $ test "failed to encode with wasm-sandbox" (ExternalFailure e)
+    pure $ test s!"failed to encode with wasm-sandbox: {x}" (ExternalFailure e)
 
 def uWasmMods := [
   "(module
@@ -172,6 +170,33 @@ def modsControl :=
      ))"
   , "(module (func (result i32)
         (block (result i32) (i32.ctz (br_if 0)))
+     ))"
+  , "(module (func (result i32)
+        (block $name (result i32) (i32.ctz (br_if 0)))
+     ))"
+  , "(module (func
+        (block $two (loop (block $zero (br_if $two))))
+     ))"
+  , "(module (func
+        (block $two (loop (block $zero (br_if $two))))
+        (block $xxx (nop))
+     ))"
+  , "(module (func
+        (block $two (loop (block $zero (br_if $two))))
+       )
+       (func $f
+        (block $one (nop))
+       )
+     )"
+  , "(module (func
+        (block $shadow (loop (block $shadow (br_if $shadow))))
+     ))"
+  , "(module (func (result i32)
+        (loop $aaaaaaaaaaaaaaaaaaaaa (result i32) (i32.const 3))
+     ))"
+  , "(module (func (result i32)
+        (if $x (result i32) (i32.const 1) (then (i32.const 4) (br $x))
+          (else (i32.const 256) (br 0)))
      ))"
   ]
 

--- a/Tests/SimpleEncodings.lean
+++ b/Tests/SimpleEncodings.lean
@@ -86,12 +86,18 @@ def testResultParses : TestSeq :=
 
 def testBlockResultConstEndParses : TestSeq :=
   testParse opP "(block (result i32) (i32.const 1) end)" $
-    (.block [(Type'.i 32)] [(.const (Type'.i 32) (.i (ConstInt.mk 32 1)))])
+    (.block .none [(Type'.i 32)] [(.const (Type'.i 32) (.i (ConstInt.mk 32 1)))])
 
 def testIfParses : TestSeq :=
-  testParse ifP "if (result i32) (then (i32.const 42)) (else (i32.const 9))" $
-    (.if [(Type'.i 32)] (.from_stack) [(.const (Type'.i 32) (.i (ConstInt.mk 32 42)))]
-          [(.const (Type'.i 32) (.i (ConstInt.mk 32 9)))])
+  group "check that if instructions parse" $
+    testParse ifP "if (result i32) (then (i32.const 42)) (else (i32.const 9))"
+      (.if .none [(Type'.i 32)]
+        (.from_stack) [(.const (Type'.i 32) (.i (ConstInt.mk 32 42)))]
+          [(.const (Type'.i 32) (.i (ConstInt.mk 32 9)))]) ++
+    testParse ifP "if $x (i32.const 1) (then (br $x)) (else (br 0))"
+      (.if (.some "x") [] (.from_operation (.const (.i 32) (.i ⟨32, 1⟩)))
+        [.br (.by_name "x")] [.br (.by_index 0)]
+      )
 
 def testFuncs : TestSeq :=
   let test' := testParse (bracketed funcP)


### PR DESCRIPTION
Problem: per the spec, structured control instructions, i.e. `block`, `loop`, and `if`, support binding optional symbolic identifiers, similar to e.g. functions. We don't support this yet, but it would be useful and good for UX.

Solution: added an optional string name field to block, loop, if operations. Supported them in the parser and in the engine. Supported overshadowing labels (or rather, according to the spec, overwriting). Added a `StateM` monad to `ExtractM` in Bytes.lean to support proper encoding of branch instructions using symbolic identifiers. Added parse and binary encoding tests to ensure correctness.

Closes #46.