### PR TITLE
Cognivore/runtime tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ wasm-sandbox
 wasm-sandbox.exe # Haha, tough chance
 wast-dump*bytes
 wast-dump*bytes.lean
+Tests/Data/testsuite

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Test/Data/testsuite"]
-	path = Test/Data/testsuite
-	url = https://github.com/WebAssembly/testsuite

--- a/Main.lean
+++ b/Main.lean
@@ -77,10 +77,12 @@ def main : IO Unit := do
     IO.println $ match ofid with
     | .none => s!"THERE IS NO FUNCTION CALLED `main`"
     | .some fid =>
+    ------------- RUNNING HERE --------------
       let eres := run store fid $ Stack.mk [se_zero, se_zero]
       match eres with
       | .ok (_, stack2) => match stack2.es with
         | [] => "UNEXPECTED RESULT"
+        ---------------- FINALLY GET STACK ENTRIES HERE ----------------
         | xs => s!"!!!!!!!!!!!!!! SUCCESS !!!!!!!!!!!!!!!!\n{xs}"
       | .error ee => s!"FAILED TO RUN `main` CORRECTLY: {ee}"
 

--- a/Tests/BinaryCompatibility.lean
+++ b/Tests/BinaryCompatibility.lean
@@ -3,34 +3,20 @@ import Megaparsec.Parsec
 import Wasm.Wast.Parser
 import Wasm.Bytes
 
+import Wasm.Tests
+
 open LSpec
 open Megaparsec.Parsec
 open Wasm.Wast.Parser
 open Wasm.Bytes
+open IO.FS
 
-inductive ExternalFailure (e : IO.Error) : Prop
-instance : Testable (ExternalFailure e) := .isFailure s!"External failure: {e}"
+open Wasm.Tests
 
-open Megaparsec.Errors.Bundle in
-inductive ParseFailure (src : String) (e : ParseErrorBundle Char String Unit) : Prop
-instance : Testable (ParseFailure src e) := .isFailure s!"Parsing:\n{src}\n{e}"
-
-open IO.Process (run) in
-def w2b (x : String) :=
-  run { cmd := "./wasm-sandbox", args := #["wast2bytes", x] } |>.toBaseIO
-
--- A very bad hasing function. It adds up the character codes of each of the string's characters, and then appends 'L' followed by the number of characters in the string to reduce the chance of collisions.
-def myHash (s : String) : String :=
-  let n := s.foldl (fun acc c => acc + c.toNat) 0
-  s!"{n}L{s.length}"
-
-def fname (s : String) : String :=
-  "./wast-dump-" ++ myHash s ++ ".bytes"
-
-/- Generic Wasm module test. -/
+/-- Generic Wasm module test. -/
 partial def testGeneric : String → ByteArray → ByteArray → TestSeq
   | mod, rs, os =>
-    let str := s!"Binary representation is compatible with {fname mod}
+    let str := s!"Binary representation is compatible with {dumpFname mod}
     {mod}"
     test str $ rs = os
 
@@ -47,30 +33,29 @@ partial def testGeneric : String → ByteArray → ByteArray → TestSeq
     h.write $ mtob parsed_module
     gO.println "It's recorded to disk at /tmp/mtob.41.wasm"
 
-Instead of this, here, we're going to:
-
+Instead of this, here, we're going to: -/
+/--
  1. Make the reference WASM bytes with `wasm-sandbox` invocation,
     as provided by function `w2b`.
  2. Read the reference bytes into a variable.
  3. Compile our bytes and read those into a variable.
- 4. Write our bytes into a file called s!"{fname}.lean".
+ 4. Write our bytes into a file called s!"{dumpFname}.lean".
  5. Byte by byte, compare the two variables, reporting errors.
 -/
-open IO.FS in
 partial def moduleTestSeq (x : String) : IO TestSeq := do
   -- Run w2b against x
   match ←w2b x with
   | .ok _ => do
     -- Read the reference bytes into a variable.
-    let ref_bytes ← readBinFile $ fname x
+    let ref_bytes ← readBinFile $ dumpFname x
     -- Compile our bytes and read those into a variable.
     match parse moduleP x with
     | .error pe =>
       pure $ test "parsing module" (ParseFailure x pe)
     | .ok module => do
       let our_bytes := mtob module
-      -- Write our bytes into a file called s!"{fname}.lean".
-      writeBinFile s!"{fname x}.lean" our_bytes
+      -- Write our bytes into a file called s!"{dumpFname}.lean".
+      writeBinFile s!"{dumpFname x}.lean" our_bytes
       pure $ testGeneric x ref_bytes our_bytes
   | .error e =>
     pure $ test s!"failed to encode with wasm-sandbox: {x}" (ExternalFailure e)
@@ -559,23 +544,8 @@ def meaningfulPrograms :=
   )"
 ]
 
-open IO.Process (run) in
-def doesWasmSandboxRun? :=
-  run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } |>.toBaseIO
-
-def withWasmSandboxRun : IO UInt32 :=
-  let testCases :=
-    [ uWasmMods, modsControl, modsLocal, modsGlobal, modsNumeric ]
-  -- TODO: test meaningful programs
-  lspecEachIO testCases.join moduleTestSeq
-
-def withWasmSandboxFail : IO UInt32 :=
-  lspecIO $ test "wasm-sandbox check"
-    (ExternalFailure "You need to have `wasm-sandbox` binary in your current work directory.
-    Please run:
-    wget https://github.com/cognivore/wasm-sandbox/releases/download/v1/wasm-sandbox && chmod +x ./wasm-sandbox")
-
 def main : IO UInt32 := do
   match (← doesWasmSandboxRun?) with
-  | .ok _ => withWasmSandboxRun
+  | .ok _ => withWasmSandboxRun moduleTestSeq [ uWasmMods, modsControl, modsLocal, modsGlobal, modsNumeric ]
+  -- TODO: test meaningful programs
   | _ => withWasmSandboxFail

--- a/Tests/RuntimeCompatibility.lean
+++ b/Tests/RuntimeCompatibility.lean
@@ -1,0 +1,52 @@
+import LSpec
+import Megaparsec.Parsec
+import Wasm.Wast.Parser
+import Wasm.Bytes
+import Wasm.Tests
+
+open LSpec
+open Megaparsec.Parsec
+open Wasm.Wast.Parser
+open Wasm.Bytes
+open Wasm.Tests
+
+/-! To test runtime compatibility between Wasm.lean engine and the reference
+implementation, we choose to constrain ourselves to running only `() -> I32`
+Wasm functions.
+Note that our engine encodes it as `Int`, not `UInt32` at the moment.
+
+Some discussion about this design choice can be read here:
+https://github.com/yatima-inc/Wasm.lean/pull/53
+ -/
+
+partial def testGeneric : String → Int → Int → TestSeq
+  | mod, os, rs =>
+    let str := s!"Running function _main_ : () -> I32 evaluates the same in Lean and Rust.
+    {mod}"
+    test str $ os = rs
+
+open IO.FS in
+partial def runWasmTestSeq (x : String) : IO TestSeq := do
+  match ←run_main x with
+  | .ok y => do
+    let yᵢ := y.trim.toInt!
+    match parseP moduleP "test" x with
+    | .error pe => pure $ test "parsing module" (ParseFailure x pe)
+    | .ok m => match runModule m with
+      | .ok our_y => pure $ testGeneric x our_y yᵢ
+      | .error ee => pure $ test "running module" (EngineFailure x ee)
+  | .error e =>
+    pure $ test s!"failed to run with wasm-sandbox: {x}" (ExternalFailure e)
+
+def basics :=
+  [ "(module
+        (func (export \"main\") (result i32)
+          (i32.const 3555)
+        )
+     )"
+  ]
+
+def main : IO UInt32 := do
+  match (← doesWasmSandboxRun?) with
+  | .ok _ => withWasmSandboxRun runWasmTestSeq [ basics ]
+  | _ => withWasmSandboxFail

--- a/Tests/SimpleEncodings.lean
+++ b/Tests/SimpleEncodings.lean
@@ -1,16 +1,15 @@
 import LSpec
+import Wasm.Tests
 
 import Megaparsec.Parsec
 import Wasm.Wast.Parser
 
 open LSpec
+open Wasm.Tests
 
 open Megaparsec.Parsec
 open Wasm.Wast.Parser
 
-open Megaparsec.Errors.Bundle in
-inductive ParseFailure (src : String) (e : ParseErrorBundle Char String Unit) : Prop
-instance : Testable (ParseFailure src e) := .isFailure s!"Parsing:\n{src}\n{e}"
 
 def testParse (parser: Parsec Char String Unit α)
               (src : String) (y : α) [BEq α] [ToString α] : TestSeq :=

--- a/Wasm/Tests.lean
+++ b/Wasm/Tests.lean
@@ -1,0 +1,77 @@
+import LSpec
+import Megaparsec.Errors.Bundle
+import Megaparsec.Parsec
+import Wasm.Engine
+import Wasm.Wast.AST
+import Wasm.Wast.Parser
+import Wasm.Bytes
+
+open LSpec
+open Megaparsec.Errors.Bundle
+open Megaparsec.Parsec
+open Wasm.Engine
+open Wasm.Wast.AST.Module
+open Wasm.Wast.Parser
+open Wasm.Bytes
+
+namespace Wasm.Tests
+
+inductive ExternalFailure (e : IO.Error) : Prop
+instance : Testable (ExternalFailure e) := .isFailure s!"External failure: {e}"
+
+open Megaparsec.Errors.Bundle in
+inductive ParseFailure (src : String) (e : ParseErrorBundle Char String Unit) : Prop
+instance : Testable (ParseFailure src e) := .isFailure s!"Parsing:\n{src}\n{e}"
+
+inductive EngineFailure (src : String) (e : EngineErrors) : Prop
+instance : Testable (EngineFailure src e) :=
+  .isFailure s!"Engine failure: {e}\n=================\n{src}"
+
+
+open IO.Process (run) in
+def w2b (x : String) :=
+  run { cmd := "./wasm-sandbox", args := #["wast2bytes", x] } |>.toBaseIO
+
+open IO.Process (run) in
+def run_main (x : String) :=
+  run { cmd := "./wasm-sandbox", args := #["run_main", x] } |>.toBaseIO
+
+def runModule (m : Module) : Except EngineErrors Int := do
+  let store := mkStore m
+  let s₀ := Stack.mk []
+  match fidByName store "main" with
+  | .none => Except.error EngineErrors.function_not_found
+  | .some fid =>
+    run store fid s₀ >>= fun (_, s₁) =>
+      match s₁ with
+      | ⟨ [y] ⟩ => match y with
+        | .num (.i ⟨32, n⟩) => pure n
+        | _ => Except.error EngineErrors.typecheck_failed
+      | _ => Except.error EngineErrors.stack_incompatible_with_results
+
+
+/-- A very bad hashing function. It adds up the character codes of each of the string's characters, and then appends 'L' followed by the number of characters in the string to reduce the chance of collisions. -/
+def badHash (s : String) : String :=
+  let n := s.foldl (fun acc c => acc + c.toNat) 0
+  s!"{n}L{s.length}"
+
+def dumpFname (s : String) : String :=
+  "./wast-dump-" ++ badHash s ++ ".bytes"
+
+open IO.Process (run) in
+def doesWasmSandboxRun? :=
+  (
+    run { cmd := "./wasm-sandbox", args := #["wast2bytes", "(module)"] } *>
+    run { cmd := "./wasm-sandbox", args := #["run_main", "(module (func (export \"main\") (result i32) (i32.const 42)))"] }
+  ) |>.toBaseIO
+
+def withWasmSandboxRun (a2t : String → IO TestSeq) (testCases : List $ List String) : IO UInt32 :=
+  lspecEachIO testCases.join a2t
+
+def withWasmSandboxFail : IO UInt32 :=
+  lspecIO $ test "wasm-sandbox check"
+    (ExternalFailure "You need to have `wasm-sandbox` binary in your current work directory.
+    Please run:
+    wget https://github.com/cognivore/wasm-sandbox/releases/download/v1/wasm-sandbox && chmod +x ./wasm-sandbox
+    Or build it from source:
+    git clone https://github.com/cognivore/wasm-sandbox.git wsrepo && cd wsrepo && cargo build --release && cp target/release/wasm-sandbox ../ && cd .. && rm -rf wsrepo")

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -29,3 +29,4 @@ lean_exe Tests.Dependent
 lean_exe Tests.Leb128
 lean_exe Tests.SimpleEncodings
 lean_exe Tests.BinaryCompatibility
+lean_exe Tests.RuntimeCompatibility

--- a/scripts/get
+++ b/scripts/get
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# With this bash script we're going to get the assets that are needed for testing and demoing Wasm.lean
+# Supported assets are the following:
+# - `sandbox.x86`
+sandbox_x86_url="https://github.com/cognivore/wasm-sandbox/releases/download/v1/wasm-sandbox"
+# - `sandbox.compile`
+# - `sandbox` (same as `sandbox.compile`)
+# - `testsuite`
+
+# Dependencies are the following:
+# - `git`
+# - `wget`
+# - `rustup`
+
+# Enjoy!
+
+##############################################################################################################
+
+# Let's start by printing help if needed and exiting
+
+verb="$1"
+shift
+
+# Check if the user asks for help
+
+if [ "$verb" = "-h" ] || [ "$verb" = "--help" ] || [ "$verb" = "help" ]; then
+    echo "Usage: $0 [sandbox.x86|sandbox.compile|sandbox|testsuite|all]"
+    exit 0
+fi
+
+# Check for Dependencies
+
+deps="git wget rustup"
+for dep in $deps; do
+    if ! command -v "$dep" &> /dev/null; then
+        echo "Error: $dep is not installed. You need the following dependencies: [ ${deps} ]"
+        exit 1
+    fi
+done
+
+# Helper variables that contain call site and script site.
+
+call_site="$(pwd)"
+# script_site="$(dirname "$(realpath "$0")")"
+
+# Helper function which traverses up until it hits the project root.
+# Project root is where the `lakefile.lean` is.
+
+function go_up() {
+    # Go up until we hit the project root
+    while [ ! -f "lakefile.lean" ]; do
+        # Check if we're already in some tricky directory like /home or /
+        # If so, exit.
+        case "$(pwd)" in
+            /) ;&
+            /home) ;&
+            /home/*) echo "Error: Could not find project root. Exiting."; exit 1 ;;
+        esac
+        cd ..
+    done
+}
+
+# I don't think there's any reason to not go_up on every invocation, so let's do it.
+
+go_up
+
+# Now let's define a "download scenario" function per asset
+
+function download_sandbox_x86() {
+    # Force-download the sandbox.x86 binary
+    wget "$sandbox_x86_url" -O wasm-sandbox.new && rm -f wasm-sandbox 2>/dev/null
+    mv wasm-sandbox{.new,}
+}
+
+function download_sandbox_compile() {
+    git clone https://github.com/cognivore/wasm-sandbox.git wasm-sandbox-repo
+    cd wasm-sandbox-repo || return
+    cargo build --release
+    cp target/release/wasm-sandbox ../
+    cd ..
+    rm -rf wasm-sandbox-repo
+}
+
+function download_testsuite() {
+    # Check if we have testuite cloned already.
+    if [ -d "Tests/Data/testsuite" ]; then
+        cd "Tests/Data/testsuite" || return
+        git pull
+    else
+        git clone https://github.com/WebAssembly/testsuite Tests/Data/testsuite
+    fi
+}
+
+function download_based_on_arch() {
+    # Check if we're on x86_64, then download precompiled binary.
+    if [ "$(uname -m)" != "x86_64" ]; then
+        download_sandbox_x86
+    else
+        download_sandbox_compile
+    fi
+}
+
+function download_all() {
+    download_based_on_arch
+    download_testsuite
+}
+
+function download_all_soft() {
+    # We don't need to compile stuff over a long time
+    if [ ! -f "wasm-sandbox" ]; then
+        download_based_on_arch
+    fi
+    download_testsuite
+}
+
+# Now we finally dispatch the verb, which isn't 'help':
+
+case "$verb" in
+    sandbox.x86) download_sandbox_x86 ;;
+    sandbox.compile) download_sandbox_compile ;;
+    sandbox) download_sandbox_compile ;;
+    testsuite) download_testsuite ;;
+    all) download_all ;;
+    *) download_all_soft ;;
+esac
+
+cd "$call_site" || exit 4


### PR DESCRIPTION
Should help *a lot* with debugging runtime divergencies such as the one you reported, @ixahedron.

Problem: No way to test runtime compatibility

Solution:
First, do some refactoring addressing that encoding runtime tests involve copypasta

 - Move common functions from RuntimeCompatibility to Wasm.Tests
 - Rename them to be more reflective of semantics
 - Use them in BinaryCompatibility
 - Scaffold RuntimeCompatibility

Then make sure that we can run "main" function from rust

 - Run a basic wasm module in the wasm-sandbox presence checker along with parsing a basic module
 - Test and fix buggy compilation from source instructions

Then we implement a way to run `() -> I32 Wasm` in Lean.
Note that our engine encodes it as Int, not UInt32 in Lean at the moment.

Finally, we implement RuntimeCompatibility tests.

 - Tie common functionality together
 - Capture Rust's stdout
 - Trim it
 - Force-convert it to int
 - Compare it with the helper function that calls Lean Wasm implementation for comparison
 - Insert it into the LSPec test wrapper